### PR TITLE
Bold display of links in left menu

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -146,7 +146,7 @@ collections:
     permalink: /programme/bazaar/:path/
   faq:
     output: true
-    permalink: /:collection/:path/
+    permalink: /:collection/:path
   programme_teams:
     output: true
     permalink: /programme/:path/


### PR DESCRIPTION
<!---
Thanks for your contribution!

Please indicate whether this PR is ready to be reviewed in your description. 
Otherwise, in case this PR is still work in progress, use the drop down menu 
next to "Create pull request" and select "Create draft pull request"
--->
As mentioned in #146 some link entries have not been displayed bold when being activated. This is fixed for the pages *Tools* and *Attending an event* by setting the permalink.

<img width="467" alt="Screenshot 2020-06-23 at 22 44 42" src="https://user-images.githubusercontent.com/8090701/85460081-2ac3e780-b5a3-11ea-8b70-4a068dcf9965.png">

Closes #146.