### PR TITLE
Added button to Indico call for abstracts at call for contributions

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -25,6 +25,7 @@ github_username: username
 minimal_mistakes_skin: default
 search: true
 future: true
+indico_base_event: https://indico.scc.kit.edu/event/863
 
 # Build settings
 markdown: kramdown

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -7,8 +7,7 @@ author: SORSE
 author_profile: false
 ---
 
-This document is work in progress!
-{: .notice--danger}
+<a href="{{site.indico_base_event}}/abstracts" class="btn btn--success" target="_blank"><i class="fas fa-pen"></i> Submit an abstract</a>
 
 Welcome to SORSE20 - A **S**eries of **O**nline **R**esearch **S**oftware **E**vents - our international answer to the COVID-19-induced cancellation of many national RSE conferences. We want to provide an opportunity for RSEs to develop and grow their skills, build new collaborations and engage with RSEs worldwide. This is an open call to all RSEs and anyone involved with research software, worldwide, to propose talks, workshops and other types of online events.
 

--- a/_posts/programme/2020-06-23-call-for-contributions.md
+++ b/_posts/programme/2020-06-23-call-for-contributions.md
@@ -10,7 +10,7 @@ sidebar:
 classes: wide
 ---
 
-TLDR: <a href="{{site.indico_base_event}}/abstracts" class="btn btn--success" target="_blank"><i class="fas fa-pen"></i> Propose an event</a>
+TLDR: <a href="{{site.indico_base_event}}/abstracts" class="btn btn--success" target="_blank"><i class="fas fa-pen"></i> Submit an abstract</a>
 
 Were you going to submit something to an RSE conference this year? Do you have a project you’d like to share? Is there a talk/workshop/panel you’d like to see happen? Then you’ve found the right place!
 
@@ -26,4 +26,4 @@ Upcoming contribution deadlines are all detailed below. Each contribution deadli
 
 See our [schedule of events]({% include fix-link.html link="/" %}) for details of what’s coming up.
 
-<a href="{{site.indico_base_event}}/abstracts" class="btn btn--success" target="_blank"><i class="fas fa-pen"></i> Propose an event</a>
+<a href="{{site.indico_base_event}}/abstracts" class="btn btn--success" target="_blank"><i class="fas fa-pen"></i> Submit an abstract</a>

--- a/_posts/programme/2020-06-23-call-for-contributions.md
+++ b/_posts/programme/2020-06-23-call-for-contributions.md
@@ -9,6 +9,9 @@ sidebar:
   nav: programme
 classes: wide
 ---
+
+TLDR: <a href="{{site.indico_base_event}}/abstracts" class="btn btn--success" target="_blank"><i class="fas fa-pen"></i> Propose an event</a>
+
 Were you going to submit something to an RSE conference this year? Do you have a project you’d like to share? Is there a talk/workshop/panel you’d like to see happen? Then you’ve found the right place!
 
 You can make a contribution to one of the event types (see the left hand menu), and/or suggest an event in the [Wishlist]({% include fix-link.html link="/programme/wishlist" %}) that you’d like to see in the series. Take a look at the [Topic Bazaar]({% include fix-link.html link=site.data.committee.programme_teams.bazaar.internal %}) if you have an idea but want to find collaborators before submitting. We’re looking for both technical and soft skills and there are no set themes this year but if a theme emerges, we may group those events together to create a half day event or a run of events over a few weeks.
@@ -22,3 +25,5 @@ The call is open to anyone wanting to propose a research software-related talk o
 Upcoming contribution deadlines are all detailed below. Each contribution deadline will have an earliest event date when events submitted prior to that deadline can take place. You can propose an event for any date or range of dates beyond this.
 
 See our [schedule of events]({% include fix-link.html link="/" %}) for details of what’s coming up.
+
+<a href="{{site.indico_base_event}}/abstracts" class="btn btn--success" target="_blank"><i class="fas fa-pen"></i> Propose an event</a>

--- a/_posts/programme/2020-06-23-call-for-contributions.md
+++ b/_posts/programme/2020-06-23-call-for-contributions.md
@@ -10,7 +10,7 @@ sidebar:
 classes: wide
 ---
 
-TLDR: <a href="{{site.indico_base_event}}/abstracts" class="btn btn--success" target="_blank"><i class="fas fa-pen"></i> Submit an abstract</a>
+<a href="{{site.indico_base_event}}/abstracts" class="btn btn--success" target="_blank"><i class="fas fa-pen"></i> Submit an abstract</a>
 
 Were you going to submit something to an RSE conference this year? Do you have a project you’d like to share? Is there a talk/workshop/panel you’d like to see happen? Then you’ve found the right place!
 

--- a/_posts/programme/2020-06-23-call-for-contributions.md
+++ b/_posts/programme/2020-06-23-call-for-contributions.md
@@ -10,9 +10,9 @@ sidebar:
 classes: wide
 ---
 
-<a href="{{site.indico_base_event}}/abstracts" class="btn btn--success" target="_blank"><i class="fas fa-pen"></i> Submit an abstract</a>
-
 Were you going to submit something to an RSE conference this year? Do you have a project you’d like to share? Is there a talk/workshop/panel you’d like to see happen? Then you’ve found the right place!
+
+<a href="{{site.indico_base_event}}/abstracts" class="btn btn--success" target="_blank"><i class="fas fa-pen"></i> Submit an abstract</a>
 
 You can make a contribution to one of the event types (see the left hand menu), and/or suggest an event in the [Wishlist]({% include fix-link.html link="/programme/wishlist" %}) that you’d like to see in the series. Take a look at the [Topic Bazaar]({% include fix-link.html link=site.data.committee.programme_teams.bazaar.internal %}) if you have an idea but want to find collaborators before submitting. We’re looking for both technical and soft skills and there are no set themes this year but if a theme emerges, we may group those events together to create a half day event or a run of events over a few weeks.
 


### PR DESCRIPTION
<!---
Thanks for your contribution!

Please indicate whether this PR is ready to be reviewed in your description. 
Otherwise, in case this PR is still work in progress, use the drop down menu 
next to "Create pull request" and select "Create draft pull request"
--->
The call for contributions now includes a link to the call for abstracts in indico. The base event url in indico is configured in ``_config.yml`` and can be accessed via ``{{site.indico_base_event}}``.
The button is currently included at the top and bottom of the page to allow convenient access.

<img width="886" alt="Screenshot 2020-06-23 at 23 30 49" src="https://user-images.githubusercontent.com/8090701/85466253-0586a780-b5aa-11ea-9136-aba3db702ab7.png">