### PR TITLE
Remove SORSE20 in CircleCi config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,12 +20,12 @@ build_jekyll: &build_jekyll
 
         # Update baseurl in config
         URL=https://${CIRCLE_BUILD_NUM}-267395254-gh.circle-artifacts.com
-        sed -i "s,^baseurl: .*,baseurl: /0,g" "_config.yml"
+        sed -i "s,^baseurl: .*,baseurl: /0/SORSE,g" "_config.yml"
         sed -i "s,^url: .*,url: $URL,g" "_config.yml"
 
         # Build site to download template
         bundle exec jekyll build
- 
+
 
 jobs:
   build-site:
@@ -54,4 +54,4 @@ jobs:
       - run: *build_jekyll
       - store_artifacts:
           path: ~/repo/_site
-          destination: ''
+          destination: SORSE

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ build_jekyll: &build_jekyll
 
         # Update baseurl in config
         URL=https://${CIRCLE_BUILD_NUM}-267395254-gh.circle-artifacts.com
-        sed -i "s,^baseurl: .*,baseurl: /0/SORSE20,g" "_config.yml"
+        sed -i "s,^baseurl: .*,baseurl: /0,g" "_config.yml"
         sed -i "s,^url: .*,url: $URL,g" "_config.yml"
 
         # Build site to download template
@@ -54,4 +54,4 @@ jobs:
       - run: *build_jekyll
       - store_artifacts:
           path: ~/repo/_site
-          destination: SORSE20
+          destination: ''


### PR DESCRIPTION
and replaces it with SORSE. We need some `destination`, so I think SORSE is fine. Otherwise the baseurl would be something like `~/repo/_site`.

Ready to be reviewed and merged @sdruskat, see https://app.circleci.com/pipelines/github/SORSE/sorse.github.io/269/workflows/00396909-f6b7-4166-8c75-00630c41b6ac/jobs/273/artifacts