### PR TITLE
Hiding awards page from navigation

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -72,8 +72,8 @@ programme:
         url: "/programme/call-for-contributions/"
       - title: "Have your say"
         url: "/programme/wishlist/"
-      - title: Awards
-        url: "/programme/awards/"
+      # - title: Awards
+      #   url: "/programme/awards/"
       - title: Panels and Discussions
         url: "/programme/panels/"
       - title: Posters and Lightning talks


### PR DESCRIPTION
<!---
Thanks for your contribution!

Please indicate whether this PR is ready to be reviewed in your description. 
Otherwise, in case this PR is still work in progress, use the drop down menu 
next to "Create pull request" and select "Create draft pull request"
--->
The awards page currently has no contents. As this page is not that relevant for cfc it was decided by @annalenalamprecht in https://github.com/SORSE/sorse.github.io/issues/49#issuecomment-646474513_ that the page can be hidden as long as we are missing the contents.