### PR TITLE
Fixed link with ending slash

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -95,7 +95,7 @@ programme:
       - title: Workshops
         url: "/programme/workshops/"
       - title: Blog Posts
-        url: /faq/howto/contribute-blog-posts/
+        url: /faq/howto/contribute-blog-posts
 
 programme_faq:
   - *sorse20


### PR DESCRIPTION
Link to blog posts from program had a slash at the end and so didn't work.

Closes #181 