### PR TITLE
Remove social links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -76,18 +76,6 @@ author:
       icon: "fab fa-fw fa-github"
       url: "https://github.com/SORSE"
 
-footer:
-  links:
-    - label: "Twitter"
-      icon: "fab fa-fw fa-twitter-square"
-      url: "https://twitter.com/"
-    - label: "GitHub"
-      icon: "fab fa-fw fa-github"
-      url: "https://github.com/"
-    - label: "Instagram"
-      icon: "fab fa-fw fa-instagram"
-      url: "https://instagram.com/"
-
 defaults:
   # _posts
   - scope:

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,20 +1,3 @@
-<div class="page__footer-follow">
-  <ul class="social-icons">
-    {% if site.data.ui-text[site.locale].follow_label %}
-      <li><strong>{{ site.data.ui-text[site.locale].follow_label }}</strong></li>
-    {% endif %}
-
-    {% if site.footer.links %}
-      {% for link in site.footer.links %}
-        {% if link.label and link.url %}
-          <li><a href="{{ link.url }}" rel="nofollow noopener noreferrer"><i class="{{ link.icon | default: 'fas fa-link' }}" aria-hidden="true"></i> {{ link.label }}</a></li>
-        {% endif %}
-      {% endfor %}
-    {% endif %}
-
-    <li><a href="{% if site.atom_feed.path %}{{ site.atom_feed.path }}{% else %}{{ '/feed.xml' | relative_url }}{% endif %}"><i class="fas fa-fw fa-rss-square" aria-hidden="true"></i> {{ site.data.ui-text[site.locale].feed_label | default: "Feed" }}</a></li>
-  </ul>
-</div>
 
 <div class="page__footer-nav">
   {% for link in site.data.navigation.footer %}


### PR DESCRIPTION
This PR removes the social links in the footer as proposed by @TeriForey in https://github.com/SORSE/sorse.github.io/issues/58#issuecomment-648817855

Now the footer looks like this:

![image](https://user-images.githubusercontent.com/9960249/85631754-67acde80-b676-11ea-8298-796da722a7fa.png)

see also https://333-267395254-gh.circle-artifacts.com/0/SORSE/index.html

closes #58 