### PR TITLE
Split test and build into two jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,9 @@ build_jekyll: &build_jekyll
 test_jekyll: &test_jekyll
   name: Test the build
   command: |
+    echo "baseurl: ''" >> _config.yml
     echo "url: ''" >> _config.yml
+
     bundle exec rake
 
 executors:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,18 +17,24 @@ workflows:
 
 
 build_jekyll: &build_jekyll
-    name: Jekyll Build
-    command: |
-        echo "Building RSE Blog for Preview"
-        cd ~/repo
+  name: Jekyll Build
+  command: |
+      echo "Building RSE Blog for Preview"
+      cd ~/repo
 
-        # Update baseurl in config
-        URL=https://${CIRCLE_BUILD_NUM}-267395254-gh.circle-artifacts.com
-        echo "baseurl: /0/SORSE" >> _config.yml
-        echo "url: $URL" >> _config.yml
+      # Update baseurl in config
+      URL=https://${CIRCLE_BUILD_NUM}-267395254-gh.circle-artifacts.com
+      echo "baseurl: /0/SORSE" >> _config.yml
+      echo "url: $URL" >> _config.yml
 
-        # Build site to download template
-        bundle exec jekyll build
+      # Build site to download template
+      bundle exec jekyll build
+
+test_jekyll: &test_jekyll
+  name: Test the build
+  command: |
+    echo "url: ''" >> _config.yml
+    bundle exec rake
 
 executors:
   jekyll-executor:
@@ -72,6 +78,4 @@ jobs:
     executor: jekyll-executor
     steps:
       - install
-      - run:
-          name: Test the build
-          command: bundle exec rake
+      - run: *test_jekyll

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,10 @@ workflows:
           filters:
             branches:
               ignore: gh-pages
+      - test-site:
+          filters:
+            branches:
+              ignore: gh-pages
 
 
 build_jekyll: &build_jekyll
@@ -34,9 +38,8 @@ test_build: &test_build
 
         bundle exec rake
 
-
-jobs:
-  build-site:
+executors:
+  jekyll-executor:
     docker:
       - image: circleci/ruby:2.4.1
     working_directory: ~/repo
@@ -44,6 +47,9 @@ jobs:
       - JEKYLL_ENV: production
       - NOKOGIRI_USE_SYSTEM_LIBRARIES: true
       - BUNDLE_PATH: ~/repo/vendor/bundle
+
+commands:
+  install:
     steps:
       - checkout
       - restore_cache:
@@ -59,8 +65,19 @@ jobs:
           key: rubygems-v1
           paths:
             - vendor/bundle
-      - run: *test_build
+
+
+jobs:
+  build-site:
+    executor: jekyll-executor
+    steps:
+      - install
       - run: *build_jekyll
       - store_artifacts:
           path: ~/repo/_site
           destination: SORSE
+  test-site:
+    executor: jekyll-executor
+    steps:
+      - install
+      - run: *test_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,19 +24,11 @@ build_jekyll: &build_jekyll
 
         # Update baseurl in config
         URL=https://${CIRCLE_BUILD_NUM}-267395254-gh.circle-artifacts.com
-        sed -i "s,^baseurl: .*,baseurl: /0/SORSE,g" "_config.yml"
-        sed -i "s,^url: .*,url: $URL,g" "_config.yml"
+        echo "baseurl: /0/SORSE" >> _config.yml
+        echo "url: $URL" >> _config.yml
 
         # Build site to download template
         bundle exec jekyll build
-
-test_build: &test_build
-    name: Test the build
-    command: |
-        sed -i "s,^baseurl: .*,baseurl: '',g" "_config.yml"
-        sed -i "s,^url: .*,url: '',g" "_config.yml"
-
-        bundle exec rake
 
 executors:
   jekyll-executor:
@@ -80,4 +72,6 @@ jobs:
     executor: jekyll-executor
     steps:
       - install
-      - run: *test_build
+      - run:
+          name: Test the build
+          command: bundle exec rake

--- a/_config.yml
+++ b/_config.yml
@@ -16,8 +16,6 @@
 title: SORSE
 logo: "/assets/images/logo.png"
 og_image: "/assets/images/sorse-banner-980x980.png"
-baseurl: ""  # for testing, also check .circleci/circle_urls.sh
-url: &url "https://sorse.github.io"
 repository: SORSE/sorse.github.io
 email: &email SORSE.enquiries@gmail.com
 description: >- # this means to ignore newlines until "baseurl:"
@@ -71,7 +69,7 @@ author:
   github: *github
   twitter: *twitter
   email: *email
-  website: *url
+  website: "https://sorse.github.io"
 
 defaults:
   # _posts


### PR DESCRIPTION
This small PR does two changes:

1. It separates the url tests from building the site and uploading artifacts (testing takes longer and fails sometimes, then we can immediately see, where the problem is)
2. it removes the `baseurl` and `url` keys from `_config.yml` as they are actually not necessary and including them makes it impossible to host this repo using Github pages in a fork

@vsoch: Are you okay with these changes?