### PR TITLE
Add events schedule

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -131,6 +131,11 @@ defaults:
     values:
       sidebar:
         nav: "programme"
+      author_profile: true
+      share: true
+      collection_button:
+        name: Schedule
+        url: /programme/
       layout: single
 
 collections:

--- a/_config.yml
+++ b/_config.yml
@@ -125,6 +125,13 @@ defaults:
       toc: true
       toc_sticky: true
       layout: programme-team
+  - scope:
+      path: ""
+      type: events
+    values:
+      sidebar:
+        nav: "programme"
+      layout: single
 
 collections:
   bazaar:
@@ -134,5 +141,8 @@ collections:
     output: true
     permalink: /:collection/:path
   programme_teams:
+    output: true
+    permalink: /programme/:path/
+  events:
     output: true
     permalink: /programme/:path/

--- a/_config.yml
+++ b/_config.yml
@@ -136,7 +136,7 @@ defaults:
       collection_button:
         name: Schedule
         url: /programme/
-      layout: single
+      layout: event
 
 collections:
   bazaar:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,6 +1,6 @@
 main:
   - title: "Programme"
-    url: /programme/call-for-contributions/ # Change to /programme/ once there is a programme page
+    url: /programme/
   - title: "Contact"
     url: /contact/
   - title: About

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -73,6 +73,7 @@ programme:
   - *sorse20
   - &programme
     title: "Programme"
+    url: /programme/
     children:
       - title: "Call for Contributions"
         url: "/programme/call-for-contributions/"

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -79,6 +79,8 @@ programme:
         url: "/programme/call-for-contributions/"
       - title: "Have your say"
         url: "/programme/wishlist/"
+      - title: Events Calendar
+        url: /programme/calendar/
       - title: "Ask us anything"
         url: "/programme/ask-us-anything/"
       # - title: Awards

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -13,6 +13,8 @@ news:
     title: SORSE
     url: /
     children:
+      - title: Upcoming events
+        url: /programme/
       - title: Aims of SORSE
         url: "/faq/about/what-is-sorse"
       - title: "Format of SORSE"
@@ -83,6 +85,8 @@ programme:
         url: /programme/calendar/
       - title: "Ask us anything"
         url: "/programme/ask-us-anything/"
+  - &teams
+    children:
       # - title: Awards
       #   url: "/programme/awards/"
       - title: Panels and Discussions
@@ -103,6 +107,7 @@ programme:
 programme_faq:
   - *sorse20
   - *programme
+  - *teams
   - *faq
 
 coc:

--- a/_events/software_demos/event-001.md
+++ b/_events/software_demos/event-001.md
@@ -1,0 +1,15 @@
+---
+title: Awesome presentation about my software
+authors:
+  - name: Some One
+    bio: "My affiliation"
+    email: nomail@someone.to
+  - name: Some One Else
+    bio: "Another affiliation"
+date: 2020-06-24T09:00:00Z
+category: software_demo
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec in nisi ut libero euismod sagittis quis a turpis. Praesent ultrices elementum erat, vel ultricies orci vulputate ut. Curabitur id dictum nulla. Curabitur lacinia nulla vitae urna fringilla, ac pretium tortor sodales. Aliquam justo orci, vulputate eget metus ut, sollicitudin vulputate lacus. In rutrum lectus ex. Maecenas venenatis, diam ac rhoncus accumsan, urna libero imperdiet metus, in elementum risus dolor vel leo. Ut eros metus, consequat sit amet turpis sed, lobortis aliquam felis. Morbi ornare condimentum arcu ut posuere. Duis nulla nisi, porta ac rhoncus vehicula, venenatis vel justo. Morbi feugiat metus nec massa dignissim, eu imperdiet purus imperdiet. Suspendisse maximus ultrices faucibus. Nunc a nibh fermentum, vulputate orci id, molestie quam.
+
+Donec nec urna sit amet sapien dictum tincidunt. Vestibulum sed lorem vel sem laoreet rutrum a at lectus. Donec faucibus, tortor nec congue aliquet, purus nunc efficitur ex, et placerat orci justo non sem. Pellentesque id imperdiet nisl, a vestibulum risus. Quisque porttitor neque id nibh malesuada, eu sodales ex mollis. Mauris sit amet leo eget ante dictum elementum ut et tellus. Pellentesque id lacus pulvinar nunc ultricies ultrices. Duis eget libero sit amet arcu auctor placerat sed vel.

--- a/_events/software_demos/event-001.md
+++ b/_events/software_demos/event-001.md
@@ -6,7 +6,10 @@ authors:
     email: nomail@someone.to
   - name: Some One Else
     bio: "Another affiliation"
-date: 2020-06-24T09:00:00Z
+date: 2020-06-30
+time:
+  - start: 2020-07-15T15:00:00Z
+    end: 2020-07-15T15:30:00Z
 category: software_demo
 ---
 

--- a/_events/software_demos/event-002.md
+++ b/_events/software_demos/event-002.md
@@ -6,7 +6,10 @@ authors:
     email: someguy@someone.to
   - name: Co Author
     bio: "Another affiliation"
-date: 2020-07-03T18:00:00Z
+date: 2020-06-30
+time:
+  - start: 2020-07-24T18:00:00Z
+    end: 2020-07-24T18:15:00Z
 category: software_demo
 ---
 

--- a/_events/software_demos/event-002.md
+++ b/_events/software_demos/event-002.md
@@ -1,0 +1,15 @@
+---
+title: Another awesome presentation about my software
+authors:
+  - name: Mario Guy
+    bio: "My affiliation"
+    email: someguy@someone.to
+  - name: Co Author
+    bio: "Another affiliation"
+date: 2020-07-03T18:00:00Z
+category: software_demo
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec in nisi ut libero euismod sagittis quis a turpis. Praesent ultrices elementum erat, vel ultricies orci vulputate ut. Curabitur id dictum nulla. Curabitur lacinia nulla vitae urna fringilla, ac pretium tortor sodales. Aliquam justo orci, vulputate eget metus ut, sollicitudin vulputate lacus. In rutrum lectus ex. Maecenas venenatis, diam ac rhoncus accumsan, urna libero imperdiet metus, in elementum risus dolor vel leo. Ut eros metus, consequat sit amet turpis sed, lobortis aliquam felis. Morbi ornare condimentum arcu ut posuere. Duis nulla nisi, porta ac rhoncus vehicula, venenatis vel justo. Morbi feugiat metus nec massa dignissim, eu imperdiet purus imperdiet. Suspendisse maximus ultrices faucibus. Nunc a nibh fermentum, vulputate orci id, molestie quam.
+
+Donec nec urna sit amet sapien dictum tincidunt. Vestibulum sed lorem vel sem laoreet rutrum a at lectus. Donec faucibus, tortor nec congue aliquet, purus nunc efficitur ex, et placerat orci justo non sem. Pellentesque id imperdiet nisl, a vestibulum risus. Quisque porttitor neque id nibh malesuada, eu sodales ex mollis. Mauris sit amet leo eget ante dictum elementum ut et tellus. Pellentesque id lacus pulvinar nunc ultricies ultrices. Duis eget libero sit amet arcu auctor placerat sed vel.

--- a/_events/talks/event-003.md
+++ b/_events/talks/event-003.md
@@ -1,0 +1,17 @@
+---
+title: A presentation
+authors:
+  - name: Some Person
+    bio: "My affiliation"
+    email: onemail@someone.to
+  - name: Some One Else
+    bio: "Another affiliation"
+  - name: Some Guy
+    bio: "Another affiliation"
+date: 2020-06-29T18:00:00Z
+category: talk
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec in nisi ut libero euismod sagittis quis a turpis. Praesent ultrices elementum erat, vel ultricies orci vulputate ut. Curabitur id dictum nulla. Curabitur lacinia nulla vitae urna fringilla, ac pretium tortor sodales. Aliquam justo orci, vulputate eget metus ut, sollicitudin vulputate lacus. In rutrum lectus ex. Maecenas venenatis, diam ac rhoncus accumsan, urna libero imperdiet metus, in elementum risus dolor vel leo. Ut eros metus, consequat sit amet turpis sed, lobortis aliquam felis. Morbi ornare condimentum arcu ut posuere. Duis nulla nisi, porta ac rhoncus vehicula, venenatis vel justo. Morbi feugiat metus nec massa dignissim, eu imperdiet purus imperdiet. Suspendisse maximus ultrices faucibus. Nunc a nibh fermentum, vulputate orci id, molestie quam.
+
+Donec nec urna sit amet sapien dictum tincidunt. Vestibulum sed lorem vel sem laoreet rutrum a at lectus. Donec faucibus, tortor nec congue aliquet, purus nunc efficitur ex, et placerat orci justo non sem. Pellentesque id imperdiet nisl, a vestibulum risus. Quisque porttitor neque id nibh malesuada, eu sodales ex mollis. Mauris sit amet leo eget ante dictum elementum ut et tellus. Pellentesque id lacus pulvinar nunc ultricies ultrices. Duis eget libero sit amet arcu auctor placerat sed vel.

--- a/_events/talks/event-003.md
+++ b/_events/talks/event-003.md
@@ -8,7 +8,10 @@ authors:
     bio: "Another affiliation"
   - name: Some Guy
     bio: "Another affiliation"
-date: 2020-06-29T18:00:00Z
+date: 2020-06-29
+time:
+  - start: 2020-07-29T18:00:00Z
+    end: 2020-07-29T18:30:00Z
 category: talk
 ---
 

--- a/_events/workshops/event-004.md
+++ b/_events/workshops/event-004.md
@@ -1,0 +1,17 @@
+---
+title: An awesome workshop
+authors:
+  - name: Workshop Guy
+    bio: "From Somewhere on Earth"
+    email: somewhere@someone.to
+  - name: Some One Else
+    bio: "Another affiliation"
+  - name: Some Guy
+    bio: "Another affiliation"
+date: 2020-07-11T18:00:00Z
+category: workshop
+---
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec in nisi ut libero euismod sagittis quis a turpis. Praesent ultrices elementum erat, vel ultricies orci vulputate ut. Curabitur id dictum nulla. Curabitur lacinia nulla vitae urna fringilla, ac pretium tortor sodales. Aliquam justo orci, vulputate eget metus ut, sollicitudin vulputate lacus. In rutrum lectus ex. Maecenas venenatis, diam ac rhoncus accumsan, urna libero imperdiet metus, in elementum risus dolor vel leo. Ut eros metus, consequat sit amet turpis sed, lobortis aliquam felis. Morbi ornare condimentum arcu ut posuere. Duis nulla nisi, porta ac rhoncus vehicula, venenatis vel justo. Morbi feugiat metus nec massa dignissim, eu imperdiet purus imperdiet. Suspendisse maximus ultrices faucibus. Nunc a nibh fermentum, vulputate orci id, molestie quam.
+
+Donec nec urna sit amet sapien dictum tincidunt. Vestibulum sed lorem vel sem laoreet rutrum a at lectus. Donec faucibus, tortor nec congue aliquet, purus nunc efficitur ex, et placerat orci justo non sem. Pellentesque id imperdiet nisl, a vestibulum risus. Quisque porttitor neque id nibh malesuada, eu sodales ex mollis. Mauris sit amet leo eget ante dictum elementum ut et tellus. Pellentesque id lacus pulvinar nunc ultricies ultrices. Duis eget libero sit amet arcu auctor placerat sed vel.

--- a/_events/workshops/event-004.md
+++ b/_events/workshops/event-004.md
@@ -6,9 +6,15 @@ authors:
     email: somewhere@someone.to
   - name: Some One Else
     bio: "Another affiliation"
+    orcid: 0000-0001-6171-7716
   - name: Some Guy
     bio: "Another affiliation"
-date: 2020-07-11T18:00:00Z
+date: 2020-06-30
+time:
+  - start: 2020-07-11T18:00:00Z
+    end: 2020-07-11T21:00:00Z
+  - start: 2020-07-12T18:00:00Z
+    end: 2020-07-12T21:00:00Z
 category: workshop
 ---
 

--- a/_includes/event-card.html
+++ b/_includes/event-card.html
@@ -1,0 +1,10 @@
+{% unless post.hidden %}
+<div class="card col-12 post-card">
+  <b class="card-title"><a href="{{ post.url | relative_url }}" rel="permalink" target="_blank">{{ post.title }}</a></b>
+  <div class="card-content" onclick="window.open('{{ post.url | relative_url }}')">
+    {% include event-summary.html event=post %}
+    <br>
+    {{ post.excerpt | markdownify | strip_html | truncate: 300 }}
+  </div>
+</div>
+{% endunless %}

--- a/_includes/event-summary-long.html
+++ b/_includes/event-summary-long.html
@@ -1,0 +1,56 @@
+{% assign event = include.event %}
+
+<p>
+{% include group-by-array collection=event.authors field="bio" %}
+{% for author in event.authors %}
+  {% assign author = site.data.authors[author] | default: author %}
+  {% assign email = author.email %}
+  {% unless email %}
+    {% for link in author.links %}
+        {% if link.label == "Email" %}
+            {% assign email = link.url %}
+        {% endif %}
+    {% endfor %}
+  {% endunless %}
+  {% assign affil_num = '' %}
+  {% for affiliation in group_names %}
+    {% if affiliation == author.bio %}
+      {% assign affil_num = forloop.index %}
+      {% break %}
+    {% endif %}
+  {% endfor %}
+  {% capture affiliation %}<sup id="fnref:{{ affil_num }}" role="doc-noteref"><a href="#fn:{{ affil_num }}" class="footnote" title="{{ author.bio }}">{{ affil_num }}</a></sup>{% endcapture %}
+  {% if email %}
+    {% assign email = email | remove: "mailto:" %}
+    {% capture email_link %} <a href="mailto:{{ email }}" title='{{ email }}'><span><i class="elastic-fai fas fa-envelope"></i></span></a>{% endcapture %}
+  {% else %}
+    {% assign email_link = '' %}
+  {% endif %}
+  {% if author.orcid %}
+    {% capture author_name %}
+    <a itemprop="sameAs" content="https://orcid.org/{{ author.orcid }}" href="https://orcid.org/{{ author.orcid }}" target="orcid.widget" rel="me noopener noreferrer" style="vertical-align:top;"><img src="{{ '/assets/images/orcid.svg' | relative_url }}" style="width:1em;margin-right:.5em;" alt="ORCID iD icon">{{ author.name }}</a>{% endcapture %}
+  {% else %}
+    {% assign author_name = author.name %}
+  {% endif %}
+  {{ author_name }}{{ affiliation }}{{ email_link}}{% unless forloop.last %}, {% endunless %}
+
+{% endfor %}
+<div id="affiliations" class="footnotes" role="doc-endnotes">
+  <ol>
+    {% for affiliation in group_names %}
+    <li id="fn:{{ forloop.index }}" role="doc-endnote">
+      {{ affiliation }}. <a href="#fnref:{{ forloop.index }}" class="reversefootnote" role="doc-backlink">&#8617;</a>
+    </li>
+    {% endfor %}
+  </ol>
+</div>
+
+</p>
+
+<ul class="page__date">
+  {% for time in event.time %}
+  <li>
+    {% include event-time.html %}
+  </li>
+  {% endfor %}
+</ul>

--- a/_includes/event-summary.html
+++ b/_includes/event-summary.html
@@ -1,0 +1,15 @@
+{% assign event = include.event %}
+
+{% if event.authors %}
+{% for author in event.authors %}
+  {% assign author = site.data.authors[author] | default: author %}
+  <b>{{ author.name }}</b>{% unless forloop.last %}, {% endunless %}
+{% endfor %}
+<ul class="page__date">
+  {% for time in event.time %}
+  <li>
+    {% include event-time.html %}
+  </li>
+  {% endfor %}
+</ul>
+{% endif %}

--- a/_includes/event-time.html
+++ b/_includes/event-time.html
@@ -1,0 +1,13 @@
+<strong><i class="far fa-clock" aria-hidden="true"></i></strong> <time datetime="{{ time.start | date_to_xmlschema }}">{{ time.start | date: "%B %-d, %Y, %H:%M %Z" }}</time>
+{% if time.end %}
+&ndash;
+<time datetime="{{ time.end | date_to_xmlschema }}">
+  {%- capture start_day -%}{{ time.start | date: "%Y-%m-%d" }}{%- endcapture -%}
+  {%- capture end_day -%}{{ time.end | date: "%Y-%m-%d" }}{%- endcapture -%}
+  {%- if start_day == end_day -%}
+  {{ time.end | date: "%H:%M %Z" }}
+  {%- else -%}
+  {{ time.end | date: "%B %-d, %Y, %H:%M %Z" }}
+  {%- endif -%}
+</time>
+{% endif %}

--- a/_includes/event.js
+++ b/_includes/event.js
@@ -1,8 +1,10 @@
+{%- for time in post.time -%}
 {
-  title  : '{{ post.title }}',
+  title  : '{{ post.title }}{% unless forloop.first %} (continued){% endunless %}',
   url    : "{{ post.url | relative_url }}",
   allDay : {% if post.all_day %}true{% else %}false{% endif %},
   category : "{{ post.category }}",
-  {% unless post.end_date %}// {% endunless %}end    : '{{ event.end_date | date_to_xmlschema }},'
-  start  : '{{ post.date | date_to_xmlschema }}'
-}
+  {% unless time.end %}// {% endunless %}end    : '{{ time.end | date_to_xmlschema }}',
+  start  : '{{ time.start | date_to_xmlschema }}'
+}{% unless forloop.last %},{% endunless %}
+{%- endfor -%}

--- a/_includes/event.js
+++ b/_includes/event.js
@@ -1,0 +1,8 @@
+{
+  title  : '{{ post.title }}',
+  url    : "{{ post.url | relative_url }}",
+  allDay : {% if post.all_day %}true{% else %}false{% endif %},
+  category : "{{ post.category }}",
+  {% unless post.end_date %}// {% endunless %}end    : '{{ event.end_date | date_to_xmlschema }},'
+  start  : '{{ post.date | date_to_xmlschema }}'
+}

--- a/_includes/events-subcollection.html
+++ b/_includes/events-subcollection.html
@@ -1,0 +1,21 @@
+{% assign entries = include.collection %}
+
+{% if include.sort_by == 'title' %}
+  {% if include.sort_order == 'reverse' %}
+    {% assign entries = entries | sort: 'title' | reverse %}
+  {% else %}
+    {% assign entries = entries | sort: 'title' %}
+  {% endif %}
+{% elsif include.sort_by == 'date' %}
+  {% if include.sort_order == 'reverse' %}
+    {% assign entries = entries | sort: 'date' | reverse %}
+  {% else %}
+    {% assign entries = entries | sort: 'date' %}
+  {% endif %}
+{% endif %}
+
+{%- for post in entries -%}
+  {%- unless post.hidden -%}
+    {% include event-card.html %}
+  {%- endunless -%}
+{%- endfor -%}

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -1,0 +1,6 @@
+{% if page.fullcalendar %}
+
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/fullcalendar@5.1.0/main.css" />
+  <script src="https://cdn.jsdelivr.net/npm/fullcalendar@5.1.0/main.js"></script>
+
+{% endif %}

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -1,0 +1,30 @@
+<div id='calendar'></div>
+[Full event calendar]({{ "/programme/calendar/" | relative_url }})
+{: .text-right}
+
+<script>
+
+ document.addEventListener('DOMContentLoaded', function() {
+   var calendarEl = document.getElementById('calendar');
+
+   var events = [
+      {% for post in site.events %}
+      {% include event.js %}{% if forloop.last %}{% else %},{% endif %}
+      {% endfor %}
+   ];
+
+   events = events.filter(e => new Date(e.start) >= new Date());
+   events.sort((e1, e2) => new Date(e1.start) - new Date(e2.start));
+
+   calendar = new FullCalendar.Calendar(calendarEl, {
+     headerToolbar: false,
+     noEventsContent: "No upcoming events",
+     timeZone: 'UTC',
+     initialView: 'listYear',
+     editable: true,
+     selectable: true,
+     events: events
+   });
+  calendar.render();
+});
+</script>

--- a/_layouts/all-events.html
+++ b/_layouts/all-events.html
@@ -1,0 +1,30 @@
+---
+layout: archive
+---
+
+{% assign collection = site[page.collection] %}
+{% include group-by-array collection=collection field="category" %}
+
+<ul class="taxonomy__index">
+  {% for category in group_names %}
+  {% assign category_name = site.data.committee.programme_teams[category].name | default: category %}
+    <li>
+      <a href="#{{ category | slugify | downcase }}">
+        <strong>{{ category_name }}</strong> <span class="taxonomy__count">{{ group_items[forloop.index0] | size }}</span>
+      </a>
+    </li>
+  {% endfor %}
+</ul>
+
+
+{{ content }}
+
+
+{% for category in group_names %}
+  {% assign category_name = site.data.committee.programme_teams[category].name | default: category %}
+  {% assign posts = group_items[forloop.index0] %}
+  <section id="{{ category | slugify | downcase }}" class="taxonomy__section">
+    <h2>{{ category_name }}</h2>
+      {% include events-subcollection.html collection=posts sort_by=page.sort_by sort_order=page.sort_order type=page.entries_layout %}
+  </section>
+{% endfor %}

--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -1,0 +1,36 @@
+---
+layout: single
+---
+
+{{ content }}
+
+<div id='calendar'></div>
+
+<script>
+
+ document.addEventListener('DOMContentLoaded', function() {
+   var calendarEl = document.getElementById('calendar');
+
+   calendar = new FullCalendar.Calendar(calendarEl, {
+     headerToolbar: {
+       left: 'prev,next today',
+       center: 'title',
+       right: 'dayGridMonth,listWeek,listDay'
+     },
+     buttonText: {
+       week: 'week',
+       day: 'day'
+     },
+     timeZone: 'UTC',
+     initialView: 'dayGridMonth',
+     editable: true,
+     selectable: true,
+     events: [
+        {% for post in site.events %}
+        {% include event.js %}{% if forloop.last %}{% else %},{% endif %}
+        {% endfor %}
+     ]
+   });
+  calendar.render();
+});
+</script>

--- a/_layouts/collection-categories.html
+++ b/_layouts/collection-categories.html
@@ -9,9 +9,10 @@ layout: archive
 
 <ul class="taxonomy__index">
   {% for category in group_names %}
+  {% assign category_name = site.data.committee.programme_teams[category].name | default: category %}
     <li>
       <a href="#{{ category | slugify | downcase }}">
-        <strong>{{ category }}</strong> <span class="taxonomy__count">{{ group_items[forloop.index0] | size }}</span>
+        <strong>{{ category_name }}</strong> <span class="taxonomy__count">{{ group_items[forloop.index0] | size }}</span>
       </a>
     </li>
   {% endfor %}

--- a/_layouts/collection-categories.html
+++ b/_layouts/collection-categories.html
@@ -1,0 +1,28 @@
+---
+layout: archive
+---
+
+{{ content }}
+
+{% assign collection = site[page.collection] %}
+{% include group-by-array collection=collection field="category" %}
+
+<ul class="taxonomy__index">
+  {% for category in group_names %}
+    <li>
+      <a href="#{{ category | slugify | downcase }}">
+        <strong>{{ category }}</strong> <span class="taxonomy__count">{{ group_items[forloop.index0] | size }}</span>
+      </a>
+    </li>
+  {% endfor %}
+</ul>
+
+
+{% for category in group_names %}
+  {% assign category_name = site.data.committee.programme_teams[category].name | default: category %}
+  {% assign posts = group_items[forloop.index0] %}
+  <section id="{{ category | slugify | downcase }}" class="taxonomy__section">
+    <h2>{{ category_name }}</h2>
+      {% include documents-subcollection.html collection=posts sort_by=page.sort_by sort_order=page.sort_order type=page.entries_layout %}
+  </section>
+{% endfor %}

--- a/_layouts/collection-categories.html
+++ b/_layouts/collection-categories.html
@@ -2,8 +2,6 @@
 layout: archive
 ---
 
-{{ content }}
-
 {% assign collection = site[page.collection] %}
 {% include group-by-array collection=collection field="category" %}
 
@@ -17,6 +15,9 @@ layout: archive
     </li>
   {% endfor %}
 </ul>
+
+
+{{ content }}
 
 
 {% for category in group_names %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -1,0 +1,9 @@
+---
+layout: single
+---
+
+{% include event-summary-long.html event=page %}
+
+{{ content }}
+
+{% include team-button.html team=page.category %}

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -13,6 +13,7 @@ header:
     - label: Submit an abstract
       url: /programme/call-for-contributions/
 excerpt: International Series of Online Research Software Events
+fullcalendar: true
 ---
 
 <aside id="twitter-holder" class="sidebar__right sticky">
@@ -23,9 +24,9 @@ Welcome to SORSE - A **S**eries of **O**nline **R**esearch **S**oftware **E**ven
 
 This is an open call to all RSEs and anyone involved with research software worldwide, to propose a talk, a workshop, a software demo, a panel or discussion, blog post or poster. After the each event, SORSE will provide an opportunity for networking and informal discussion with other participants in small groups.
 
-Any questions, read [more](faq/about/what-is-sorse) or [get in touch](contact/)!
+Any questions, read [more](faq/about/what-is-sorse), [get in touch](contact/), or see [upcoming events](#upcoming-events)!
 
-### News
+## News
 
 {% if paginator %}
   {% assign posts = paginator.categories["news"] %}
@@ -39,4 +40,6 @@ Any questions, read [more](faq/about/what-is-sorse) or [get in touch](contact/)!
 
 {% include paginator.html %}
 
-### Upcoming Events
+## Upcoming Events
+
+{% include upcoming-events.html %}

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -38,3 +38,5 @@ Any questions, read [more](faq/about/what-is-sorse) or [get in touch](contact/)!
 {% endfor %}
 
 {% include paginator.html %}
+
+### Upcoming Events

--- a/_pages/programme/calendar.md
+++ b/_pages/programme/calendar.md
@@ -32,7 +32,7 @@ fullcalendar: true
      selectable: true,
      events: [{% for event in site.events %}{
        title  : '{{ event.title }}',
-       url    : '{{ event.url }}',
+       url    : "{{ event.url | relative_url }}",
        allDay : {% if event.all_day %}true{% else %}false{% endif %},
        {% unless event.end_date %}// {% endunless %}end    : '{{ event.end_date | date_to_xmlschema }}'
        start  : '{{ event.date | date_to_xmlschema }}'

--- a/_pages/programme/calendar.md
+++ b/_pages/programme/calendar.md
@@ -1,0 +1,44 @@
+---
+title: Calendar
+permalink: /programme/calendar/
+sidebar:
+  nav:  programme
+classes: wide
+toc: true
+toc_sticky: true
+fullcalendar: true
+---
+
+<div id='calendar'></div>
+
+<script>
+
+ document.addEventListener('DOMContentLoaded', function() {
+   var calendarEl = document.getElementById('calendar');
+
+   var calendar = new FullCalendar.Calendar(calendarEl, {
+     headerToolbar: {
+       left: 'prev,next today',
+       center: 'title',
+       right: 'dayGridMonth,listWeek,listDay'
+     },
+     buttonText: {
+       week: 'week',
+       day: 'day'
+     },
+     timeZone: 'UTC',
+     initialView: 'dayGridMonth',
+     editable: true,
+     selectable: true,
+     events: [{% for event in site.events %}{
+       title  : '{{ event.title }}',
+       url    : '{{ event.url }}',
+       allDay : {% if event.all_day %}true{% else %}false{% endif %},
+       {% unless event.end_date %}// {% endunless %}end    : '{{ event.end_date | date_to_xmlschema }}'
+       start  : '{{ event.date | date_to_xmlschema }}'
+      }{% if forloop.last %}{% else %},{% endif %}{% endfor %}
+     ]
+   });
+  calendar.render();
+});
+</script>

--- a/_pages/programme/calendar.md
+++ b/_pages/programme/calendar.md
@@ -7,38 +7,5 @@ classes: wide
 toc: true
 toc_sticky: true
 fullcalendar: true
+layout: calendar
 ---
-
-<div id='calendar'></div>
-
-<script>
-
- document.addEventListener('DOMContentLoaded', function() {
-   var calendarEl = document.getElementById('calendar');
-
-   var calendar = new FullCalendar.Calendar(calendarEl, {
-     headerToolbar: {
-       left: 'prev,next today',
-       center: 'title',
-       right: 'dayGridMonth,listWeek,listDay'
-     },
-     buttonText: {
-       week: 'week',
-       day: 'day'
-     },
-     timeZone: 'UTC',
-     initialView: 'dayGridMonth',
-     editable: true,
-     selectable: true,
-     events: [{% for event in site.events %}{
-       title  : '{{ event.title }}',
-       url    : "{{ event.url | relative_url }}",
-       allDay : {% if event.all_day %}true{% else %}false{% endif %},
-       {% unless event.end_date %}// {% endunless %}end    : '{{ event.end_date | date_to_xmlschema }}'
-       start  : '{{ event.date | date_to_xmlschema }}'
-      }{% if forloop.last %}{% else %},{% endif %}{% endfor %}
-     ]
-   });
-  calendar.render();
-});
-</script>

--- a/_pages/programme/index.md
+++ b/_pages/programme/index.md
@@ -1,0 +1,9 @@
+---
+title: Programme
+layout: collection-categories
+collection: events
+permalink: /programme/
+---
+
+HERE SHOULD BE A SCHEDULE
+{: notice--alert}

--- a/_pages/programme/index.md
+++ b/_pages/programme/index.md
@@ -3,6 +3,8 @@ title: Programme
 layout: collection-categories
 collection: events
 permalink: /programme/
+sidebar:
+  nav:  programme
 ---
 
 HERE SHOULD BE A SCHEDULE

--- a/_pages/programme/index.md
+++ b/_pages/programme/index.md
@@ -5,7 +5,9 @@ collection: events
 permalink: /programme/
 sidebar:
   nav:  programme
+fullcalendar: true
 ---
 
-HERE SHOULD BE A SCHEDULE
-{: notice--alert}
+## Upcoming events
+
+{% include upcoming-events.html %}

--- a/_pages/programme/index.md
+++ b/_pages/programme/index.md
@@ -1,6 +1,6 @@
 ---
 title: Programme
-layout: collection-categories
+layout: all-events
 collection: events
 permalink: /programme/
 sidebar:

--- a/_sass/fc.scss
+++ b/_sass/fc.scss
@@ -1,6 +1,6 @@
 
 // override table properties of minimal-mistakes
-.fc-daygrid table {
+.fc-daygrid table, .fc-list-table {
   display: table;
   margin-bottom: 0;
 }

--- a/_sass/fc.scss
+++ b/_sass/fc.scss
@@ -1,0 +1,15 @@
+
+// override table properties of minimal-mistakes
+.fc-daygrid table {
+  display: table;
+  margin-bottom: 0;
+}
+
+
+#calendar {
+
+  font-family: Arial, Helvetica Neue, Helvetica, sans-serif;
+  font-size: $type-size-8;
+  max-width: 1100px;
+  margin: 0 auto;
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -8,6 +8,7 @@
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
 @import "minimal-mistakes"; // main partials
 @import "card";
+@import "fc";
 
 .masthead {
   background-color: rgba(151, 49, 110, 0.3);

--- a/assets/images/orcid.svg
+++ b/assets/images/orcid.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 19.1.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 256 256" style="enable-background:new 0 0 256 256;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill:#A6CE39;}
+	.st1{fill:#FFFFFF;}
+</style>
+<path class="st0" d="M256,128c0,70.7-57.3,128-128,128C57.3,256,0,198.7,0,128C0,57.3,57.3,0,128,0C198.7,0,256,57.3,256,128z"/>
+<g>
+	<path class="st1" d="M86.3,186.2H70.9V79.1h15.4v48.4V186.2z"/>
+	<path class="st1" d="M108.9,79.1h41.6c39.6,0,57,28.3,57,53.6c0,27.5-21.5,53.6-56.8,53.6h-41.8V79.1z M124.3,172.4h24.5
+		c34.9,0,42.9-26.5,42.9-39.7c0-21.5-13.7-39.7-43.7-39.7h-23.7V172.4z"/>
+	<path class="st1" d="M88.7,56.8c0,5.5-4.5,10.1-10.1,10.1c-5.6,0-10.1-4.6-10.1-10.1c0-5.6,4.5-10.1,10.1-10.1
+		C84.2,46.7,88.7,51.3,88.7,56.8z"/>
+</g>
+</svg>


### PR DESCRIPTION
This WIP implements the basis for showing events on the website. For this purpose we add an `_events` collection, 

- each event is assigned to a specific category (e.g. Software demo, talk, etc.). 
- each event does have a `date` attribute that is supposed to show the date and time of the event and can be used to be displayed in the schedule and the upcoming events.
- the upcoming events should be on the [front page](http://www.philipp-s-sommer.de/sorse.github.io/#upcoming-events)
- the full schedule of events should be on the [/programme/](http://www.philipp-s-sommer.de/sorse.github.io/programme/) page

I plan to create a custom layout for event pages, such as I did for the `_bazaar` collection, to show all the authors, date, etc.. Currently it only uses the default `single` layout.

@vsoch:

- how shall we display the upcoming events? Looking at the docs of [fullcalendar.io](https://fullcalendar.io/), I could not find a useful function for it. We could show the events within the current week, but I don't think this is the best approach
- can we actually filter the events on the calendar? E.g. to only display events of a specific category?

The rendered webpage of this PR can be seen at http://philipp-s-sommer.de/sorse.github.io
 