### PR TITLE
Adapt links and buttons

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -66,7 +66,7 @@ h1, h2, h3, h4, h5, h6 {
   font-family: 'Karla','Helvetica' sans-serif;
 }
 
-.toc .active a{
+.toc .active a, .toc a:visited{
   color: #646464;
   background-color: #dadada;
 }
@@ -75,7 +75,7 @@ h1, h2, h3, h4, h5, h6 {
   color: #474747;
 }
 
-// Hyperlinks 
+// Hyperlinks
 
 a {
   color: #740B70;
@@ -118,24 +118,24 @@ nav.pagination{
   font-size: 0.85em;
 }
 
-.btn--success{
+.btn--success, .btn--success:visited{
   background-color: #1b8275;
-  &:hover, &:visited, &:focus{
+  &:hover, &:focus{
     background-color: #2e9f91;
   }
 }
 
-.btn--danger{
+.btn--danger, .btn--danger:visited{
   background-color: #e95371;
-  &:hover, &:visited, &:focus{
+  &:hover, &:focus{
     background-color: #ec6a84;
   }
 }
 
-.btn--info{
+.btn--info, .btn--info:visited{
   background-color: #d8b117;
   color: #0c0c0c;
-  &:hover, &:visited, &:focus{
+  &:hover, &:focus{
     background-color: #e7bf21;
     color: #0c0c0c;
   }
@@ -145,9 +145,9 @@ a:focus, button:focus{
   outline: none;
 }
 
-.btn--primary{
+.btn--primary, .btn--primary:visited{
   background-color: #474747;
-  &:hover, &:visited, &:focus{
+  &:hover, &:focus{
     background-color: #646464;
   }
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -4,6 +4,9 @@
 
 @charset "utf-8";
 
+$link-color: #740B70;
+$link-color-visited: #9B4C97;
+$link-color-hover: mix(#000, $link-color, 50%);
 
 @import "minimal-mistakes/skins/{{ site.minimal_mistakes_skin | default: 'default' }}"; // skin
 @import "minimal-mistakes"; // main partials
@@ -73,14 +76,6 @@ h1, h2, h3, h4, h5, h6 {
 }
 
 // Hyperlinks
-
-a {
-  color: #740B70;
-}
-
-a:visited{
-  color:  #9B4C97;
-}
 
 a.missing:link {
   color: rgba(255, 0, 0, 1.0);

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -20,9 +20,6 @@ h1, h2, h3, h4, h5, h6 {
 .masthead {
   background-color: #0c0c0c;
   border-bottom: none;
-  -webkit-box-shadow: 0px 1px 5px 0px rgba(	41, 41, 41,0.7);
-  -moz-box-shadow: 0px 1px 5px 0px rgba(	41, 41, 41,0.7);
-  box-shadow: 0px 1px 5px 0px rgba(	41, 41, 41,0.7);
 }
 
 .page__hero {


### PR DESCRIPTION
This PR adapts some small styling things:

- cd3a874 removes the shadow-box around the masthead, I feel like this is distracting
  - [new](https://434-267395254-gh.circle-artifacts.com/0/SORSE/index.html) 
    ![image](https://user-images.githubusercontent.com/9960249/86339313-bac4f980-bc53-11ea-926e-bfc1071de58f.png)
  - [old](https://429-267395254-gh.circle-artifacts.com/0/SORSE/index.html) 
    ![image](https://user-images.githubusercontent.com/9960249/86339280-b0a2fb00-bc53-11ea-9905-9ff45996853c.png)
  it's hard to see on some screens anyway, but on a high-res display, it looked weird to me
- 8712fd2 let's the buttons look the same, regardless whether they have been visited or not. Otherwise you also see some flickering effect when hovering over a visited button
  - see the buttons in https://434-267395254-gh.circle-artifacts.com/0/SORSE/contact/index.html
  - vs the old ones in https://429-267395254-gh.circle-artifacts.com/0/SORSE/contact/index.html
- cdc83cd uses the `$link-color` variable, rather than `a { color: ...; }`. Furthermore it sets the `$link-color-hover` variable to use a darker version of the default color (without this, you also see some flickering when hovering over a visited link). See the link in
  - https://434-267395254-gh.circle-artifacts.com/0/SORSE/faq/about/what-is-sorse.html
  - vs the old one in https://429-267395254-gh.circle-artifacts.com/0/SORSE/faq/about/what-is-sorse.html

@trallard: If you are happy with these changes, please approve and we merge it. 

link #212 