### PR TITLE
Add talks and poster tags for mentoring FAQ

### DIFF
--- a/_faq/howto/get-help.md
+++ b/_faq/howto/get-help.md
@@ -4,5 +4,7 @@ tags:
   - How it works
   - Submission
   - Getting help
+  - Talks
+  - Posters and Lightning talks
 ---
 Yes! We can help you to find a suitable mentor for your event. We have a pool of members of the RSE community who are happy to offer their advice to junior presenters. You can ask for a mentor when you [submit an abstract]({{ "/programme/call-for-contributions/" | relative_url }}).

--- a/_faq/howto/mentor.md
+++ b/_faq/howto/mentor.md
@@ -3,5 +3,7 @@ title: I have experience presenting on conferences and would be happy to offer a
 tags:
   - How it works
   - Contributing
+  - Talks
+  - Posters and Lightning talks
 ---
 Thank you! :tada: Just write us an email at [{{ site.email }}](mailto:{{ site.email }}). We will add you to our pool of mentors and get you in touch with a mentee who can benefit from your experience when there is a request.

--- a/_includes/card.html
+++ b/_includes/card.html
@@ -18,7 +18,7 @@
     {% else %}
     {% assign avatar = "/assets/images/bio-photo.jpg" %}
     {% endif %}
-    <img width="200px" src="{% include fix-link.html link=avatar %}" alt="{{ info.name }}">
+    <img width="200px" src="{{ avatar | relative_url }}" alt="{{ info.name }}">
     <p class="card-content">
       {% if info.long_name %}<span class="content-line">{{ info.long_name }}</span>{% endif %}
       {% if info.affiliation %}<span class="content-line">{{ info.affiliation }}</span>{% endif %}

--- a/_includes/faq-card.html
+++ b/_includes/faq-card.html
@@ -1,6 +1,6 @@
 {% unless post.hidden %}
 <div class="card col-12 post-card">
-  <b class="card-title"><a href="{{ post.url | relative_url }}" rel="permalink" target="_blank">{{ post.title }}</a></b>
+  <p class="card-title"><a href="{{ post.url | relative_url }}" rel="permalink" target="_blank">{{ post.title }}</a></p>
   <div class="card-content" onclick="window.open('{{ post.url | relative_url }}')">
     {{ post.excerpt | markdownify | strip_html | truncate: 160 }}
   </div>

--- a/_sass/card.scss
+++ b/_sass/card.scss
@@ -36,6 +36,10 @@
 	font-weight: bold;
 }
 
+p.card-title {
+	margin: 0 0 0;
+}
+
 .card .card-content {
 	padding: 2px 15px;
 	font-size: $type-size-7;


### PR DESCRIPTION
a followup of #220 that closes #221

@MarionBWeinzierl, the FAQs now appear under the [Talks tag][talkstag], [Posters tag][posterstag], as well as on the [Talks page][talkspage] and [Posters page][posterspage].

Does this work for you?

[talkstag]: https://521-267395254-gh.circle-artifacts.com/0/SORSE/faq/index.html#talks
[posterstag]: https://521-267395254-gh.circle-artifacts.com/0/SORSE/faq/index.html#posters-and-lightning-talks
[talkspage]: https://521-267395254-gh.circle-artifacts.com/0/SORSE/programme/talks/index.html#faq
[posterspage]: https://521-267395254-gh.circle-artifacts.com/0/SORSE/programme/posters/index.html#faq