### PR TITLE
Use default timezone

### DIFF
--- a/_includes/coc-deadlines.js
+++ b/_includes/coc-deadlines.js
@@ -1,6 +1,6 @@
 {%- for deadline in site.data.coc_deadlines -%}
-{%- capture deadline_start -%}{{ deadline }}T23:59:58Z{%- endcapture -%}
-{%- capture deadline_end -%}{{ deadline }}T23:59:59Z{%- endcapture -%}
+{%- capture deadline_start -%}{{ deadline }}T23:00:00-0100{%- endcapture -%}
+{%- capture deadline_end -%}{{ deadline }}T23:00:00-0100{%- endcapture -%}
 {
   title  : 'Submission deadline',
   url    : "{{ '/programme/call-for-contributions/' | relative_url }}",

--- a/_includes/coc-deadlines.js
+++ b/_includes/coc-deadlines.js
@@ -4,14 +4,10 @@
 {
   title  : 'Submission deadline',
   url    : "{{ '/programme/call-for-contributions/' | relative_url }}",
-  {% if include.background %}
   display: "block",
   color  : "#d8b117",
   textColor: "#740B70",
   classNames: ["fg-coc-deadline"],  // to change the font-weight
-  {% else %}
-  color  : "#d8b117",
-  {% endif %}
   start  : "{{ deadline_start | date_to_xmlschema }}",
   end    : "{{ deadline_end | date_to_xmlschema }}"
 }{% unless forloop.last %},{% endunless %}

--- a/_includes/coc-deadlines.js
+++ b/_includes/coc-deadlines.js
@@ -5,9 +5,10 @@
   title  : 'Submission deadline',
   url    : "{{ '/programme/call-for-contributions/' | relative_url }}",
   {% if include.background %}
-  allDay: true,
-  display: "background",
-  backgroundColor  : "rgba(216, 177, 23, 0.3)",
+  display: "block",
+  color  : "#d8b117",
+  textColor: "#740B70",
+  classNames: ["fg-coc-deadline"],  // to change the font-weight
   {% else %}
   color  : "#d8b117",
   {% endif %}

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -20,7 +20,6 @@
    calendar = new FullCalendar.Calendar(calendarEl, {
      headerToolbar: false,
      noEventsContent: "No upcoming events",
-     timeZone: 'UTC',
      initialView: 'listYear',
      editable: true,
      selectable: true,

--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -21,7 +21,6 @@ layout: single
        week: 'week',
        day: 'day'
      },
-     timeZone: 'UTC',
      initialView: 'dayGridMonth',
      editable: true,
      selectable: true,

--- a/_sass/fc.scss
+++ b/_sass/fc.scss
@@ -14,6 +14,6 @@
   margin: 0 auto;
 }
 
-:root {
-  --fc-bg-event-opacity: 1.0;
+.fg-coc-deadline {
+  font-weight: bold;
 }


### PR DESCRIPTION
@vsoch: the calendar so far had the UTC timezone, although I think it would be better to use the local one. This works fine for the [list view](https://533-267395254-gh.circle-artifacts.com/0/SORSE/programme/index.html), but it might be a bit misleading for the [calendar](https://533-267395254-gh.circle-artifacts.com/0/SORSE/programme/calendar/index.html) as the submission deadlines allDay events get shifted to a different day...

![image](https://user-images.githubusercontent.com/9960249/87482336-811bc780-c631-11ea-95da-e0b25c2d77a1.png)
