### PR TITLE
Add mentoring post

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -75,11 +75,13 @@ programme:
     title: "Programme"
     children:
       - title: "Call for Contributions"
-        url: "/programme/call-for-contributions/"
+        url: /programme/call-for-contributions/
       - title: "Have your say"
-        url: "/programme/wishlist/"
+        url: /programme/wishlist/
       - title: "Ask us anything"
-        url: "/programme/ask-us-anything/"
+        url: /programme/ask-us-anything/
+      - title: Mentoring at SORSE
+        url: /programme/mentoring/
       # - title: Awards
       #   url: "/programme/awards/"
       - title: Panels and Discussions

--- a/_faq/howto/get-help.md
+++ b/_faq/howto/get-help.md
@@ -6,5 +6,6 @@ tags:
   - Getting help
   - Talks
   - Posters and Lightning talks
+  - Mentoring
 ---
 Yes! We can help you to find a suitable mentor for your event. We have a pool of members of the RSE community who are happy to offer their advice to junior presenters. You can ask for a mentor when you [submit an abstract]({{ "/programme/call-for-contributions/" | relative_url }}).

--- a/_faq/howto/mentor.md
+++ b/_faq/howto/mentor.md
@@ -5,5 +5,6 @@ tags:
   - Contributing
   - Talks
   - Posters and Lightning talks
+  - Mentoring
 ---
 Thank you! :tada: Just write us an email at [{{ site.email }}](mailto:{{ site.email }}). We will add you to our pool of mentors and get you in touch with a mentee who can benefit from your experience when there is a request.

--- a/_posts/programme/2020-06-23-call-for-contributions.md
+++ b/_posts/programme/2020-06-23-call-for-contributions.md
@@ -8,6 +8,7 @@ tags:
 sidebar:
   nav: programme
 classes: wide
+id: 1
 ---
 
 Were you going to submit something to an RSE conference this year? Do you have a project you’d like to share? Is there a talk/workshop/panel you’d like to see happen? Then you’ve found the right place!

--- a/_posts/programme/2020-06-24-ask-us-anything-sessions.md
+++ b/_posts/programme/2020-06-24-ask-us-anything-sessions.md
@@ -8,6 +8,7 @@ tags:
 sidebar:
   nav: programme
 classes: wide
+id: 1
 ---
 
 Each Wednesday at 9am UTC you can sign up to a 'Ask us Anything' session held on zoom where you can put suggestions to us for an event, run through how your idea would work with the tools that we are planning to use or anything else! Sign up below for one of the sessions.

--- a/_posts/programme/2020-07-15-mentoring.md
+++ b/_posts/programme/2020-07-15-mentoring.md
@@ -1,0 +1,19 @@
+---
+title: "Mentoring at SORSE"
+category: news
+permalink: /programme/mentoring/
+tags:
+  - contribution
+sidebar:
+  nav: programme
+id: 1
+---
+Presenting at a conference, be it face-to-face or online, can be daunting, especially if you do not have a lot of experience presenting. Presenting online brings additional challenges, like handling of the technology, the (more or less) anonymous online-space, and the strange feeling of being in front of a camera.
+
+Whether you are a first-time presenter or not, if you feel that you could do with some practical advice for preparing and/or presenting your poster or talk, we can help you. We have a pool of volunteers from the RSE community who are happy to share their experience in presenting in online and offline conferences, and to give you a hand with your presentation. Just indicate that you would like mentoring when you submit your contribution, and give some details in which areas you would like help.
+
+Similarly, if you just need some advice or practice using the online tools, just let us know!
+
+As SORSE is an ongoing event series, we are also always looking for more mentors. So, if you have experience with presenting and would be happy to help a junior/less experienced presenter, please drop us an email at sorse.enquiries@gmail.com and we will add you to our mentor pool. When there is a request for a mentor we will get in touch with the person from the pool we feel is most suited to help this particular mentee.
+
+{% include faq-cards-tag.html title="FAQ" tag="Mentoring" %}

--- a/_posts/programme/2020-07-15-mentoring.md
+++ b/_posts/programme/2020-07-15-mentoring.md
@@ -14,6 +14,6 @@ Whether you are a first-time presenter or not, if you feel that you could do wit
 
 Similarly, if you just need some advice or practice using the online tools, just let us know!
 
-As SORSE is an ongoing event series, we are also always looking for more mentors. So, if you have experience with presenting and would be happy to help a junior/less experienced presenter, please drop us an email at sorse.enquiries@gmail.com and we will add you to our mentor pool. When there is a request for a mentor we will get in touch with the person from the pool we feel is most suited to help this particular mentee.
+As SORSE is an ongoing event series, we are also always looking for more mentors. So, if you have experience with presenting and would be happy to help a junior/less experienced presenter, please drop us an email at [sorse.enquiries@gmail.com](mailto:sorse.enquiries@gmail.com) and we will add you to our mentor pool. When there is a request for a mentor we will get in touch with the person from the pool we feel is most suited to help this particular mentee.
 
 {% include faq-cards-tag.html title="FAQ" tag="Mentoring" %}


### PR DESCRIPTION
This PR adds a new post with the text by @MarionBWeinzierl to inform about mentoring.

The initial idea was to add it to the call-for-contributions page, but to me it reads well like a stand-alone article :) So I'd make a new post for it. It then also appears on the front-page under [news](https://542-267395254-gh.circle-artifacts.com/0/SORSE/index.html#news).

To keep the connection to the call for contributions, I made them related posts and they appear at the bottom of the site (see the bottom of the [mentoring][mentoring] and [call for contributions][cfc] posts, or the screenshot below).

![image](https://user-images.githubusercontent.com/9960249/87540362-d5f62700-c69f-11ea-9a64-61a89adf3834.png)

What do you think about this approach @ClaireWyatt and @MarionBWeinzierl?

[mentoring]: https://542-267395254-gh.circle-artifacts.com/0/SORSE/programme/mentoring/index.html
[cfc]: https://542-267395254-gh.circle-artifacts.com/0/SORSE/programme/call-for-contributions/index.html