### PR TITLE
Use indico instead of a google form to register as participant

### DIFF
--- a/_faq/about/03-costs.md
+++ b/_faq/about/03-costs.md
@@ -13,5 +13,3 @@ All data will be deleted from Indico after each event. The data will **not** be 
 
 No! It’s completely free to the community with the national RSE Groups from many countries collaborating to bring this to you.
 
-
-[indico]: https://indico.scc.kit.edu

--- a/_faq/about/03-costs.md
+++ b/_faq/about/03-costs.md
@@ -6,10 +6,10 @@ tags:
 ---
 ## Registration
 
-Registration for each event will be via dedicated registration link on its webpage.
+Registration for each event will be available via Indico. Select the event from the 
+[events calendar](){: .missing} and click the _Register_ button.
 All data will be deleted from Indico after each event. The data will **not** be passed to Zoom or Discord. It will be possible to join the Zoom events via a link and a browser therefore no Zoom account is needed. The link and password to each event will be emailed to the registered participants an hour before the event is due to start.  If you agree for the sponsors to contact you when completing the registration form, the basic information of name and email address will be forwarded to the sponsors.
 
 ## Do I need to pay to attend SORSE events?
 
 No! It’s completely free to the community with the national RSE Groups from many countries collaborating to bring this to you.
-

--- a/_faq/about/03-costs.md
+++ b/_faq/about/03-costs.md
@@ -6,7 +6,7 @@ tags:
 ---
 ## Registration
 
-Registration for each event will be via dedicated registration link for each event on our submission platform [indico][indico].
+Registration for each event will be via dedicated registration link on its webpage.
 All data will be deleted from the form after each event. The data will **not** be passed to Zoom or Discord. It will be possible to join the Zoom events via a link and a browser therefore no Zoom account is needed. The link and password to each event will be emailed to the registered participants an hour before the event is due to start.  If you agree for the sponsors to contact you when completing the registration form, the basic information of name and email address will be forwarded to the sponsors.
 
 ## Do I need to pay to attend SORSE events?

--- a/_faq/about/03-costs.md
+++ b/_faq/about/03-costs.md
@@ -7,7 +7,7 @@ tags:
 ## Registration
 
 Registration for each event will be via dedicated registration link on its webpage.
-All data will be deleted from the form after each event. The data will **not** be passed to Zoom or Discord. It will be possible to join the Zoom events via a link and a browser therefore no Zoom account is needed. The link and password to each event will be emailed to the registered participants an hour before the event is due to start.  If you agree for the sponsors to contact you when completing the registration form, the basic information of name and email address will be forwarded to the sponsors.
+All data will be deleted from Indico after each event. The data will **not** be passed to Zoom or Discord. It will be possible to join the Zoom events via a link and a browser therefore no Zoom account is needed. The link and password to each event will be emailed to the registered participants an hour before the event is due to start.  If you agree for the sponsors to contact you when completing the registration form, the basic information of name and email address will be forwarded to the sponsors.
 
 ## Do I need to pay to attend SORSE events?
 

--- a/_faq/about/03-costs.md
+++ b/_faq/about/03-costs.md
@@ -6,8 +6,12 @@ tags:
 ---
 ## Registration
 
-Registration for each event will be via a simple Google Form owned by Soc-RSE. All data will be deleted from the form after each event. The data will **not** be passed to Zoom or Discord. It will be possible to join the Zoom events via a link and a browser therefore no Zoom account is needed. The link and password to each event will be emailed to the registered participants an hour before the event is due to start.  If you agree for the sponsors to contact you when completing the registration form, the basic information of name and email address will be forwarded to the sponsors. 
+Registration for each event will be via dedicated registration link for each event on our submission platform [indico][indico].
+All data will be deleted from the form after each event. The data will **not** be passed to Zoom or Discord. It will be possible to join the Zoom events via a link and a browser therefore no Zoom account is needed. The link and password to each event will be emailed to the registered participants an hour before the event is due to start.  If you agree for the sponsors to contact you when completing the registration form, the basic information of name and email address will be forwarded to the sponsors.
 
 ## Do I need to pay to attend SORSE events?
 
-No! It’s completely free to the community with the national RSE Groups from many countries collaborating to bring this to you. 
+No! It’s completely free to the community with the national RSE Groups from many countries collaborating to bring this to you.
+
+
+[indico]: https://indico.scc.kit.edu

--- a/_faq/howto/attendance.md
+++ b/_faq/howto/attendance.md
@@ -4,8 +4,9 @@ tags:
   - How it works
 ---
 
-Registration for each event will be via a simple Google Form owned by [Soc-RSE]({% include fix-link.html link=site.data.committee.ukRSE.internal %}) (see [Registration and Fees]({% include fix-link.html link="/faq/about/costs" %})).
+Every event has a registration link on the website where you can sign up in order
+to take part (see [Registration and Fees]({% include fix-link.html link="/faq/about/costs" %})).
 
 Events will be recorded so that they can be run multiple times to suit different time zones and encourage communities to come together to network within different regions. A presenter can pre-record their event if they wish and the programme team will provide assistance with this process. For certain events, like workshops and poster sessions, we will be using Zoom breakout rooms which allow for direct interaction with the speaker via audio and video. We will also use Slack space ([join here](https://docs.google.com/forms/d/e/1FAIpQLSc9LqOWGwA1xDvSgy81eimcb9s0cNBFso0zv0_HoZz16G1M5w/viewform?c=0&w=1)) to allow continuing discussions that will remain available after each individual event.
 
-Webinars will allow speakers to present, share their screen or webcam and attendees will have the opportunity to ask questions and answer polls via the built-in Q&A system of Zoom webinars. Questions will then be read out in the Q&A part of the session and answered live by the speakers. 
+Webinars will allow speakers to present, share their screen or webcam and attendees will have the opportunity to ask questions and answer polls via the built-in Q&A system of Zoom webinars. Questions will then be read out in the Q&A part of the session and answered live by the speakers.

--- a/_faq/howto/attendance.md
+++ b/_faq/howto/attendance.md
@@ -4,7 +4,7 @@ tags:
   - How it works
 ---
 
-Every event has a registration link on its webpage where you can sign up in order
+Every event has a registration link on its webpage where you can sign up
 to take part (see [Registration and Fees]({% include fix-link.html link="/faq/about/costs" %})).
 
 Events will be recorded so that they can be run multiple times to suit different time zones and encourage communities to come together to network within different regions. A presenter can pre-record their event if they wish and the programme team will provide assistance with this process. For certain events, like workshops and poster sessions, we will be using Zoom breakout rooms which allow for direct interaction with the speaker via audio and video. We will also use Slack space ([join here](https://docs.google.com/forms/d/e/1FAIpQLSc9LqOWGwA1xDvSgy81eimcb9s0cNBFso0zv0_HoZz16G1M5w/viewform?c=0&w=1)) to allow continuing discussions that will remain available after each individual event.

--- a/_faq/howto/attendance.md
+++ b/_faq/howto/attendance.md
@@ -4,7 +4,7 @@ tags:
   - How it works
 ---
 
-Every event has a registration link on the website where you can sign up in order
+Every event has a registration link on its webpage where you can sign up in order
 to take part (see [Registration and Fees]({% include fix-link.html link="/faq/about/costs" %})).
 
 Events will be recorded so that they can be run multiple times to suit different time zones and encourage communities to come together to network within different regions. A presenter can pre-record their event if they wish and the programme team will provide assistance with this process. For certain events, like workshops and poster sessions, we will be using Zoom breakout rooms which allow for direct interaction with the speaker via audio and video. We will also use Slack space ([join here](https://docs.google.com/forms/d/e/1FAIpQLSc9LqOWGwA1xDvSgy81eimcb9s0cNBFso0zv0_HoZz16G1M5w/viewform?c=0&w=1)) to allow continuing discussions that will remain available after each individual event.

--- a/_faq/howto/tools.md
+++ b/_faq/howto/tools.md
@@ -5,4 +5,6 @@ tags:
 ---
 During the series, we will be using Zoom meeting and Zoom webinar as well as live streaming the events via YouTube Live for presenting sessions, interacting with the talk speakers as well as for software demos, panels and workshops. No registration is required to view events via either platform.
 
+To participate via zoom, you need to register for the individual events on indico, but it's free and you do not need an account (see [here]({{ "/faq/about/costs" | relative_url }})).
+
 We will also use Discord for our poster session and for persistant chat, you can join the [UK RSE slack space](https://docs.google.com/forms/d/e/1FAIpQLSc9LqOWGwA1xDvSgy81eimcb9s0cNBFso0zv0_HoZz16G1M5w/viewform?c=0&w=1).

--- a/_pages/privacy.md
+++ b/_pages/privacy.md
@@ -39,8 +39,8 @@ toc_sticky: true
 
 - We use a Google form to submit to the topic bazaar, but this is also stated
   separately [here]({% include fix-link.html link=submit_topic %}).
-- Participants register via the [indico](https://indico.scc.kit.edu) platform
-  ([privacy statement](https://indico.scc.kit.edu/event/863/page/550-privacy-policy))
+- Participants register via the [indico](https://indico.scc.kit.edu/category/95/) platform
+  using a dedicated registration link.
 - By registering you give consent to store your contact information.
 - We keep this information (participation details) until one month after each event.
 - Upon request your data can be removed earlier.

--- a/_pages/privacy.md
+++ b/_pages/privacy.md
@@ -41,7 +41,7 @@ toc_sticky: true
   separately [here]({% include fix-link.html link=submit_topic %}).
 - Participants register using a Google form for events.
 - By registering you give consent to store your contact information.
-- We keep this information (participation details) until one mongth after each event.
+- We keep this information (participation details) until one month after each event.
 - Upon request your data can be removed earlier.
 - You have the right to access your data anytime by [contacting us](/contact/).
 - We only store data that you have provided us via the registration form,

--- a/_pages/privacy.md
+++ b/_pages/privacy.md
@@ -39,7 +39,8 @@ toc_sticky: true
 
 - We use a Google form to submit to the topic bazaar, but this is also stated
   separately [here]({% include fix-link.html link=submit_topic %}).
-- Participants register using a Google form for events.
+- Participants register via the [indico](https://indico.scc.kit.edu) platform
+  ([privacy statement](https://indico.scc.kit.edu/event/863/page/550-privacy-policy))
 - By registering you give consent to store your contact information.
 - We keep this information (participation details) until one month after each event.
 - Upon request your data can be removed earlier.


### PR DESCRIPTION
As discussed quite some time ago on slack, we'd like to use indico for the registration of participants for an event. Therefore I updated the [privacy policy][privacy], as well as the FAQs about [how to attend an event][attend] and [registration and fees][fees].

@ClaireWyatt and @eileen-kuehn, did I forget something?

@eileen-kuehn: in the privacy policy, I linked to the privacy policy of our SORSE event. Do I need to use something different here?

[privacy]: https://554-267395254-gh.circle-artifacts.com/0/SORSE/privacy/index.html
[attend]: https://554-267395254-gh.circle-artifacts.com/0/SORSE/faq/howto/attendance.html
[fees]: https://554-267395254-gh.circle-artifacts.com/0/SORSE/faq/about/costs.html