### PR TITLE
Add registration button

### DIFF
--- a/_events/workshops/event-004.md
+++ b/_events/workshops/event-004.md
@@ -15,6 +15,7 @@ time:
     end: 2020-07-11T21:00:00Z
   - start: 2020-07-12T18:00:00Z
     end: 2020-07-12T21:00:00Z
+registration_url: https://indico.scc.kit.edu/event/720/
 category: workshop
 ---
 

--- a/_events/workshops/event-005.md
+++ b/_events/workshops/event-005.md
@@ -1,0 +1,20 @@
+---
+title: Not yet scheduled
+authors:
+  - name: Workshop Guy
+    bio: "From Somewhere on Earth"
+    email: somewhere@someone.to
+  - name: Some One Else
+    bio: "Another affiliation"
+    orcid: 0000-0001-6171-7716
+  - name: Some Guy
+    bio: "Another affiliation"
+date: 2020-06-30
+category: workshop
+---
+
+Dummy event that has not yet been scheduled.
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec in nisi ut libero euismod sagittis quis a turpis. Praesent ultrices elementum erat, vel ultricies orci vulputate ut. Curabitur id dictum nulla. Curabitur lacinia nulla vitae urna fringilla, ac pretium tortor sodales. Aliquam justo orci, vulputate eget metus ut, sollicitudin vulputate lacus. In rutrum lectus ex. Maecenas venenatis, diam ac rhoncus accumsan, urna libero imperdiet metus, in elementum risus dolor vel leo. Ut eros metus, consequat sit amet turpis sed, lobortis aliquam felis. Morbi ornare condimentum arcu ut posuere. Duis nulla nisi, porta ac rhoncus vehicula, venenatis vel justo. Morbi feugiat metus nec massa dignissim, eu imperdiet purus imperdiet. Suspendisse maximus ultrices faucibus. Nunc a nibh fermentum, vulputate orci id, molestie quam.
+
+Donec nec urna sit amet sapien dictum tincidunt. Vestibulum sed lorem vel sem laoreet rutrum a at lectus. Donec faucibus, tortor nec congue aliquet, purus nunc efficitur ex, et placerat orci justo non sem. Pellentesque id imperdiet nisl, a vestibulum risus. Quisque porttitor neque id nibh malesuada, eu sodales ex mollis. Mauris sit amet leo eget ante dictum elementum ut et tellus. Pellentesque id lacus pulvinar nunc ultricies ultrices. Duis eget libero sit amet arcu auctor placerat sed vel.

--- a/_includes/event-summary-long.html
+++ b/_includes/event-summary-long.html
@@ -1,6 +1,5 @@
 {% assign event = include.event %}
 
-<p>
 {% include group-by-array collection=event.authors field="bio" %}
 {% for author in event.authors %}
   {% assign author = site.data.authors[author] | default: author %}
@@ -45,8 +44,6 @@
   </ol>
 </div>
 
-</p>
-
 {% if event.time %}
 <ul class="page__date">
   {% for time in event.time %}
@@ -58,3 +55,4 @@
 {% else %}
 <div class="notice--info" style="display: table-cell;"><i>This event will be scheduled soon</i></div>
 {% endif %}
+{% include registration-button.html %}

--- a/_includes/event-summary-long.html
+++ b/_includes/event-summary-long.html
@@ -47,6 +47,7 @@
 
 </p>
 
+{% if event.time %}
 <ul class="page__date">
   {% for time in event.time %}
   <li>
@@ -54,3 +55,6 @@
   </li>
   {% endfor %}
 </ul>
+{% else %}
+<div class="notice--info" style="display: table-cell;"><i>This event will be scheduled soon</i></div>
+{% endif %}

--- a/_includes/event-summary-long.html
+++ b/_includes/event-summary-long.html
@@ -55,4 +55,3 @@
 {% else %}
 <div class="notice--info" style="display: table-cell;"><i>This event will be scheduled soon</i></div>
 {% endif %}
-{% include registration-button.html %}

--- a/_includes/event-summary.html
+++ b/_includes/event-summary.html
@@ -5,6 +5,7 @@
   {% assign author = site.data.authors[author] | default: author %}
   <b>{{ author.name }}</b>{% unless forloop.last %}, {% endunless %}
 {% endfor %}
+{% if event.time %}
 <ul class="page__date">
   {% for time in event.time %}
   <li>
@@ -12,4 +13,7 @@
   </li>
   {% endfor %}
 </ul>
+{% else %}
+<div class="notice--info" style="display: table-cell;"><i>This event will be scheduled soon</i></div>
+{% endif %}
 {% endif %}

--- a/_includes/registration-button.html
+++ b/_includes/registration-button.html
@@ -1,0 +1,9 @@
+{% if page.registration_url %}
+<a class="btn btn--success" href="{{ page.registration_url }}">
+  <i class="fas fa-feather-alt"></i> Register
+</a>
+{% else %}
+<div class="notice--info" style="display: table-cell;">
+  <i>Registration will open soon</i>
+</div>
+{% endif %}

--- a/_includes/registration-button.html
+++ b/_includes/registration-button.html
@@ -3,7 +3,7 @@
   <i class="fas fa-feather-alt"></i> Register
 </a>
 {% else %}
-<div class="notice--info" style="display: table-cell;">
+<span class="notice--info">
   <i>Registration will open soon</i>
-</div>
+</span>
 {% endif %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -6,4 +6,5 @@ layout: single
 
 {{ content }}
 
+{% include registration-button.html %}
 {% include team-button.html team=page.category %}


### PR DESCRIPTION
And here is the last one: As we will publish the events on the website, even before it has been scheduled, we need to highlight this. Furthermore, I added a button to link to the registration.

Here is how they look:
- [final][final]
- [registration did not yet open][no-registration]
- [not yet scheduled][no-time]

not sure about the styling. to me, it's getting actually too many buttons. what do you think @vsoch?

[final]: https://584-267395254-gh.circle-artifacts.com/0/SORSE/programme/workshops/event-004/index.html
[no-registration]: https://584-267395254-gh.circle-artifacts.com/0/SORSE/programme/software_demos/event-002/index.html
[no-time]: https://584-267395254-gh.circle-artifacts.com/0/SORSE/programme/workshops/event-005/index.html