### PR TITLE
Show all PDF authors in case there are no affiliations available

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ _site
 Gemfile.lock
 .tweet-cache
 ci/*.md
+ci/*.pdf
+ci/pandoc_run.sh

--- a/ci/env.txt
+++ b/ci/env.txt
@@ -1,0 +1,7 @@
+INPUT_WORKDIR=ci
+INPUT_PAPER_DIR=.
+INPUT_LATEX_TEMPLATE=latex.template.sorse
+INPUT_PDF_TYPE=pdf
+INPUT_PNG_LOGO=../assets/images/logo-large.png
+INPUT_VARIABLES_FILE=sorse-variables.txt
+INPUT_MAPPING_FILE=sorse-mapping.txt

--- a/ci/latex.template.sorse
+++ b/ci/latex.template.sorse
@@ -307,7 +307,9 @@ $if(authors)$
   $if(authors.affiliation)$
     \author[$authors.affiliation$]{$authors.name$}
   $else$
-    \author{$authors.name$}
+    % create an author with an empty affiliation. Adding hspace{-1ex} removes
+    % the extra space inserted.
+    \author[ \hspace{-1ex}]{$authors.name$}
   $endif$
   $endfor$
 $endif$
@@ -316,6 +318,9 @@ $if(affiliations)$
   $for(affiliations)$
     \affil[$affiliations.index$]{$affiliations.name$}
   $endfor$
+$else$
+  % authblk apparently requires at least one affiliation
+  \affil[ ]{ }
 $endif$
 \date{\vspace{-5ex}}
 


### PR DESCRIPTION
we need a little hack to display all authors in case there have been no affiliations specified. the `authblk` library needs it, apparently, otherwise it uses the standard latex methodology, which would be like `\author{author1 \and author2 \and ...}`

fixes #265 

