### PR TITLE
add doi badge to events

### DIFF
--- a/_includes/event-summary-long.html
+++ b/_includes/event-summary-long.html
@@ -1,5 +1,11 @@
 {% assign event = include.event %}
 
+{% if event.doi %}
+<p>
+    <a href="https://doi.org/{{ event.doi }}"><img src="https://zenodo.org/badge/DOI/{{ event.doi }}.svg" alt="DOI"></a>
+</p>
+{% endif %}
+
 {% for author in event.authors %}
   {% assign author = site.data.authors[author] | default: author %}
   {% assign email = author.email %}


### PR DESCRIPTION
This PR adds a badge to show the DOI of the event on the corresponding event page.

Here is a preview how this would look like: https://863-267395254-gh.circle-artifacts.com/0/SORSE/programme/talks/event-010/index.html