### PR TITLE
Split panels into panels and discussions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ task :test do
   options = { :assume_extension => true,
               :allow_hash_href => true,
               file_ignore: [/assets\/js\/add-to-calendar-button/],
-              url_ignore: [/twitter.com/, /www.turing.ac.uk/, /www.linkedin.com/. /benalman.com/],
+              url_ignore: [/twitter.com/, /www.turing.ac.uk/, /www.linkedin.com/],
               :typhoeus => {
                   :ssl_verifypeer => false,
                   :ssl_verifyhost => 0}

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ task :test do
   options = { :assume_extension => true,
               :allow_hash_href => true,
               file_ignore: [/assets\/js\/add-to-calendar-button/],
-              url_ignore: [/twitter.com/, /www.turing.ac.uk/, /www.linkedin.com/],
+              url_ignore: [/twitter.com/, /www.turing.ac.uk/, /www.linkedin.com/. /benalman.com/],
               :typhoeus => {
                   :ssl_verifypeer => false,
                   :ssl_verifyhost => 0}

--- a/_data/committee/members.yml
+++ b/_data/committee/members.yml
@@ -40,6 +40,7 @@
     - deRSE
     - operating
     - panels
+    - discussions
     - programme
     - website
     - talks
@@ -254,6 +255,7 @@
     - nlRSE
     - programme
     - panels
+    - discussions
     - workshops
     - operating
 - name: Marion Weinzierl
@@ -269,6 +271,7 @@
     - coc
     - talks
     - panels
+    - discussions
 - name: Louise Brown
   affiliation: Composites Research Group, University of Nottingham
   location: Nottingham, UK

--- a/_data/committee/programme_teams.yml
+++ b/_data/committee/programme_teams.yml
@@ -14,8 +14,11 @@ awards:
   name: Awards
   internal: /programme/awards/
 panels:
-  name: Panels and Discussions
+  name: Panel Discussions
   internal: /programme/panels/
+discussions:
+  name: Open Discussions
+  internal: /programme/discussions/
 bazaar:
   name: Topic Bazaar
   internal: /programme/bazaar/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -91,8 +91,10 @@ programme:
     children:
       # - title: Awards
       #   url: "/programme/awards/"
-      - title: Panels and Discussions
+      - title: Panel Discussions
         url: "/programme/panels/"
+      - title: Open Discussions
+        url: "/programme/discussions/"
       - title: Posters and Lightning talks
         url: "/programme/posters/"
       - title: Software demos

--- a/_faq/discussions/abstract.md
+++ b/_faq/discussions/abstract.md
@@ -1,11 +1,10 @@
 ---
 tags:
 - Submission
-- Panel Discussions
-title: What should be in my Panel Discussion abstract
+- Open Discussions
+title: What should be in my Open Discussion abstract
 ...
 Please describe your topic, how its is relevant to the RSE community right now,
 how the topic of the session aligns with the topic of the conference in general,
 and what is the added advantage of discussing it with the broader audience.
-Please also mention how the expertises of your plenary
-speakers will shed light on different aspects of the topic. 
+Please also list subtopics that can be discussed in breakout groups.

--- a/_programme_teams/discussions.md
+++ b/_programme_teams/discussions.md
@@ -1,0 +1,12 @@
+---
+title: Open Discussions
+team: discussions
+---
+
+Propose the Discussion Session topic if there is something that you would like to discuss with a broader audience and get opinions and ideas from fellow RSEs.
+This session should include an introduction to the discussion topic and the specific questions that the participants should address.
+Depending on the number of participants, you may consider splitting the group into the breakout rooms with 4-5 people each.
+
+This session lasts 1½ hours long, and we ask groups to take notes. We recommend that in the last 20 minutes of the session groups turn their notes into a speed blog post, which will  then be published.
+
+The proposal should describe how the topic of the session aligns with the topic of the conference and what is the added advantage of discussing it with the broader audience.

--- a/_programme_teams/discussions.md
+++ b/_programme_teams/discussions.md
@@ -3,10 +3,10 @@ title: Open Discussions
 team: discussions
 ---
 
-Propose the Discussion Session topic if there is something that you would like to discuss with a broader audience and get opinions and ideas from fellow RSEs.
+Propose a Discussion Session if there is something that you would like to discuss with a broader audience and get opinions and ideas from fellow RSEs.
 This session should include an introduction to the discussion topic and the specific questions that the participants should address.
 Depending on the number of participants, you may consider splitting the group into the breakout rooms with 4-5 people each.
 
-This session lasts 1½ hours long, and we ask groups to take notes. We recommend that in the last 20 minutes of the session groups turn their notes into a speed blog post, which will  then be published.
+This session is 1.5 hours long, and we ask groups to take notes. We recommend that in the last 20 minutes of the session groups turn their notes into a speed blog post, which will  then be published.
 
 The proposal should describe how the topic of the session aligns with the topic of the conference and what is the added advantage of discussing it with the broader audience.

--- a/_programme_teams/panels.md
+++ b/_programme_teams/panels.md
@@ -1,20 +1,8 @@
 ---
-title: "Panels and Discussions"
+title: Panel Discussions
 team: panels
 ---
-
-## Panel session
 
 Panel discussions in SORSE don’t differ much from those at an in-person conference. They include a group of people (the panel) who discuss a specific topic. Panel discussions are moderated, with a moderator introducing the panel and the topic, and asking the panel a predefined set of questions, before opening the session up for discussion with the audience. The general discussion part is also moderated, and questions can be asked in written form by the audience.
 
 A panel discussion session should not be longer than 90 minutes, with about half reserved for the moderated panel discussion. When submitting your idea for a panel session, you should ideally already have candidates for the panel in mind. Having said that, we are also happy to help finding suitable panel members if you cannot come up with a full panel. We also offer the possibility that up to two places in your panel are advertised to the SORSE community, so that interested SORSE participants get the chance to be on the panel. Please indicate if you want to offer panel seats to the SORSE community.
-
-## Open discussion
-
-Propose the Discussion Session topic if there is something that you would like to discuss with a broader audience and get opinions and ideas from fellow RSEs.
-This session should include an introduction to the discussion topic and the specific questions that the participants should address.
-Depending on the number of participants, you may consider splitting the group into the breakout rooms with 4-5 people each.
-
-This session lasts 1½ hours long, and we ask groups to take notes. We recommend that in the last 20 minutes of the session groups turn their notes into a speed blog post, which will  then be published.
-
-The proposal should describe how the topic of the session aligns with the topic of the conference and what is the added advantage of discussing it with the broader audience.


### PR DESCRIPTION
as mentioned in #280 (and #284), panels and discussions are split, as we also split them in indico. All members of the panels team have been associated with the discussions team. The `panels` name is now `Panel Discussions`, whereas the `discussions` name is now `Open discusssions`.

@sdruskat, I'd be happy if you could approve this PR. Here are the changes:

- [a discussions team][team] is now listed
- [the original panels page][origpan] has been splitted into [panels][panels] and [discussions][discussions]
- [the submission faq][origfaq] has been splitted into a [panels faq][panfaq] and a [discussions faq][discfaq] 

Furthermore I added `Open discussions` to the [programme][programme] sidebar.
 
closes #284 

[team]: https://931-267395254-gh.circle-artifacts.com/0/SORSE/programme/discussions/index.html#team
[origpan]: https://sorse.github.io/programme/panels/
[panels]: https://931-267395254-gh.circle-artifacts.com/0/SORSE/programme/panels/index.html
[discussions]: https://931-267395254-gh.circle-artifacts.com/0/SORSE/programme/discussions/index.html
[origfaq]: https://sorse.github.io/faq/panels/abstract
[panfaq]: https://931-267395254-gh.circle-artifacts.com/0/SORSE/faq/panels/abstract.html
[discfaq]: https://931-267395254-gh.circle-artifacts.com/0/SORSE/faq/discussions/abstract.html
[programme]: https://931-267395254-gh.circle-artifacts.com/0/SORSE/programme/index.html