### PR TITLE
add page with calendar buttons

### DIFF
--- a/_includes/add-to-calendar-button.html
+++ b/_includes/add-to-calendar-button.html
@@ -1,12 +1,17 @@
+{%- assign post = event | default: post | default: page %}
+{%- assign title = include.title | default: post.title | default: page.title %}
+{%- assign excerpt = include.excerpt | default: post.excerpt | default: page.excerpt %}
+{%- assign event_id = post.id | split: '/' | last %}
 <div title="Add to Calendar" class="add-to-calendar">
     <span class="start">{{ time.start | date_to_xmlschema }}</span>
     {%- if time.end %}
     <span class="end">{{ time.end | date_to_xmlschema }}</span>
     {%- endif %}
+    <span class="id">{{ event_id }}</span>
     <span class="timezone">UTC</span>
-    <span class="title">{{ page.title }}</span>
-    <span class="description">{{ page.excerpt | markdownify | strip_html }}</span>
-    <span class="location">{{ site.url }}{{ site.baseurl }}/{{ page.url }}</span>
+    <span class="title">{{ title }}</span>
+    <span class="description">{{ excerpt | markdownify | strip_html }}</span>
+    <span class="location">{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}/{% endif %}{{ page.url }}</span>
     <span class="organizer_email">{{ site.email }}</span>
     <span class="organizer">{{ site.author.name }}</span>
 </div>

--- a/_pages/programme/calendar-buttons.md
+++ b/_pages/programme/calendar-buttons.md
@@ -1,0 +1,24 @@
+---
+title: Event buttons
+permalink: /programme/calendar-buttons/
+sidebar:
+  nav:  programme
+fullcalendar: true
+---
+
+{% assign events = '' | split: '' %}
+{% for post in site.events %}
+    {% if post.time %}
+        {% assign events = events | push: post %}
+    {% endif %}
+{% endfor %}
+
+{% for post in events %}
+{%- assign event_id = post.id | split: '/' | last %}
+## {{ event_id }}: {{ post.title }}
+<div>
+{% for time in post.time %}
+{% include event-time.html %}
+{% endfor %}
+</div>
+{% endfor %}


### PR DESCRIPTION
this PR adds a page that lists all calendar buttons of the events. It's not linked anywhere in the navigation, but will help to keep the google calendar up-to-date.

here is the preview of the page: https://1024-267395254-gh.circle-artifacts.com/0/SORSE/programme/calendar-buttons/index.html

it will be accessible via https://sorse.github.io/programme/calendar-buttons/.