### PR TITLE
add link to shared google calendar

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,7 @@ minimal_mistakes_skin: default
 search: true
 future: true
 indico_base_event: https://indico.scc.kit.edu/event/863
+shared_calendar: https://calendar.google.com/calendar?cid=YXRnbTJiNXZiam42dGpyaTllNHI1a2tra2NAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ
 
 twitter:
   username: *twitter

--- a/_includes/event-summary-long.html
+++ b/_includes/event-summary-long.html
@@ -62,6 +62,7 @@
   </li>
   {% endfor %}
 </ul>
+<sup><a href="{{ site.shared_calendar }}" class="footnote">Subscribe to all SORSE events</a></sup>
 {% else %}
 <div class="notice--info" style="display: table-cell;"><i>This event will be scheduled soon</i></div>
 {% endif %}

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -1,6 +1,7 @@
 <div id='calendar'></div>
 <p class="text-right">
   <a href='{{ "/programme/calendar/" | relative_url }}'>Full event calendar</a>
+  <a href="{{ site.shared_calendar }}">Subscribe to all events</a>
 </p>
 
 <script>

--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -5,6 +5,10 @@ layout: single
 {{ content }}
 
 <div id='calendar'></div>
+<br>
+<p class="text-right">
+    <a href="{{ site.shared_calendar }}">Subscribe to all events</a>
+</p>
 
 <aside class="sidebar__right events-sidebar">
   {% for post in site.events %}


### PR DESCRIPTION
This PR adds a link to the shared Google calendar that lists all SORSE events (see #302). I did add a link

- to the upcoming events on the front page: https://1034-267395254-gh.circle-artifacts.com/0/SORSE/index.html#upcoming-events
- to the upcoming events on the programme page: https://1034-267395254-gh.circle-artifacts.com/0/SORSE/programme/index.html
- to the full calendar page: https://1034-267395254-gh.circle-artifacts.com/0/SORSE/programme/calendar/index.html
- to the individual event pages: https://1034-267395254-gh.circle-artifacts.com/0/SORSE/programme/discussions/event-013/index.html for instance

comments are highly appreciated