### PR TITLE
remove timezone from add-to-calendar button

### DIFF
--- a/_includes/add-to-calendar-button.html
+++ b/_includes/add-to-calendar-button.html
@@ -8,7 +8,6 @@
     <span class="end">{{ time.end | date_to_xmlschema }}</span>
     {%- endif %}
     <span class="id">{{ event_id }}</span>
-    <span class="timezone">UTC</span>
     <span class="title">{{ title }}</span>
     <span class="description">{{ excerpt | markdownify | strip_html }}</span>
     <span class="location">{{ site.url }}{% if site.baseurl %}{{ site.baseurl }}/{% endif %}{{ page.url }}</span>


### PR DESCRIPTION
This fixes a bug with the add-to-calendar button. We do already write the time in an iso-formatted string, and adding the timezone as well apparently duplicates this. Therefore I remove the timezone with this PR.

I did test it for .ics and the google calendar. @cc-a, could you have a quick look for the office one?

You can test it with the button here: it should appear at September 2nd on 1:10PM UTC. https://1036-267395254-gh.circle-artifacts.com/0/SORSE/programme/talks/event-001/index.html

closes #287