### PR TITLE
Zoom button

### DIFF
--- a/_events/talks/event-001.md
+++ b/_events/talks/event-001.md
@@ -19,7 +19,8 @@ time:
     - start: 2020-09-02T13:10:00Z
       end: 2020-09-02T13:50:00Z
 date: 2020-08-19
-last_modified_at: 2020-08-26
+meeting_url: https://zoom.us/j/95982897830
+last_modified_at: 2020-09-02
 registration_url: https://docs.google.com/forms/d/e/1FAIpQLSetlGKtfCxxaAjtHEGxaQ58o360tn9y5BTqHypvc2qnly5CnQ/viewform
 ---
 The Carpentries vision is to be the leading inclusive community teaching data and coding skills. Our first lesson program, Software Carpentry, was founded on several core values, including feedback, gratitude, and collaboration. The role research and data plays in your personal and professional life may contribute to your personal values and confidence in working with data. Have you ever considered your journey to data, your personal values, and whether they align? During this talk we will explore your personal journey to data and research, all while contemplating the following: **How do your personal values align with your work as a Research Software Engineer?** This talk is a pulse check. Be prepared to take notes, dig deep, and wrestle with issues of equity, inclusion, and accessibility.

--- a/_events/talks/event-002.md
+++ b/_events/talks/event-002.md
@@ -22,6 +22,8 @@ time:
     - start: 2020-09-02T13:50:00Z
       end: 2020-09-02T14:30:00Z
 date: 2020-08-19
+meeting_url: https://zoom.us/j/95982897830
+last_modified_at: 2020-09-02
 registration_url: https://docs.google.com/forms/d/e/1FAIpQLSetlGKtfCxxaAjtHEGxaQ58o360tn9y5BTqHypvc2qnly5CnQ/viewform
 ---
 The focus of the talk is on the ways in which women are discursively constructed

--- a/_includes/zoom-button.html
+++ b/_includes/zoom-button.html
@@ -1,0 +1,5 @@
+{% if page.meeting_url %}
+<a class="btn btn--success btn--zoom" href="{{ page.meeting_url }}">
+  <i class="fas fa-video"></i> Join
+</a>
+{% endif %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -10,6 +10,7 @@ layout: single
 {% include event-supplements.html %}
 </p>
 {% include registration-button.html %}
+{% include zoom-button.html %}
 {% include team-button.html team=page.category %}
 {%- capture download_link %}/downloads/{{ page.id | split: '/' | last }}.pdf{%- endcapture %}
 <a class="btn btn--success" href="{{ download_link | relative_url }}" target='_blank'>

--- a/_posts/programme/2020-08-19-kickoff.md
+++ b/_posts/programme/2020-08-19-kickoff.md
@@ -39,6 +39,9 @@ and networking in breakout rooms.
 The event will take place as a Zoom Webinar and will switch to a regular Zoom session for discussion and networking in breakout groups. Connection details
 will be sent to all registered participants in advance of the event.
 
+If you haven't registered, you can still join by clicking the _Join_ button
+above.
+
 ## Mailing list
 A mailing list that will be used only for event updates and notifications is
 available. If you’d like to be notified of upcoming SORSE events, you can join

--- a/_posts/programme/2020-08-19-kickoff.md
+++ b/_posts/programme/2020-08-19-kickoff.md
@@ -11,6 +11,8 @@ time:
     start: 2020-09-02T13:00:00Z
     end: 2020-09-02T15:00:00Z
 registration_url: https://docs.google.com/forms/d/e/1FAIpQLSetlGKtfCxxaAjtHEGxaQ58o360tn9y5BTqHypvc2qnly5CnQ/viewform
+meeting_url: https://zoom.us/j/95982897830
+last_modified_at: 2020-09-02
 ---
 To kick our series off, we’re delighted to announce that the SORSE Launch
 Event will take place 13:00-15:00 UTC on Wednesday 2nd September. We’re
@@ -21,6 +23,7 @@ pleased to be welcoming two keynote speakers at this event:
 
 <div>
     {% include registration-button.html %}
+    {% include zoom-button.html %}
     {% assign time = page.time %}
     {% include add-to-calendar-button.html %}
 </div>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -8,6 +8,9 @@ $link-color: #740B70;
 $link-color-visited: #9B4C97;
 $link-color-hover: mix(#000, $link-color, 50%);
 
+$btn-zoom-color: #2D8CFF;
+$btn-zoom-color-hover: mix(#000, $btn-zoom-color, 50%);
+
 $karla: "Karla", sans-serif;
 $header-font-family: $karla;
 
@@ -130,6 +133,15 @@ nav.pagination{
   }
   &:hover{
     background-color: $btn-success-color-hover;
+  }
+}
+
+.btn--zoom{
+  &, &:visited, &:focus{
+    background-color: $btn-zoom-color;
+  }
+  &:hover{
+    background-color: $btn-zoom-color-hover;
   }
 }
 


### PR DESCRIPTION
This adds zoom buttons to kickoff and the corresponding event pages. They are now automatically inserted for every event that defines a 

```yaml
meeting_url: ...
```
in the frontmatter.

here are the previews of the button:

- kickoff: https://1063-267395254-gh.circle-artifacts.com/0/SORSE/programme/kickoff/index.html
- talk 1: https://1063-267395254-gh.circle-artifacts.com/0/SORSE/programme/talks/event-001/index.html
- talk 2: https://1063-267395254-gh.circle-artifacts.com/0/SORSE/programme/talks/event-002/index.html