### PR TITLE
Remove Kickoff traces

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -12,8 +12,6 @@ header:
   actions:
     - label: Submit an abstract
       url: /programme/call-for-contributions/
-    - label: Kickoff on September, 2nd
-      url: /programme/kickoff/
     - label: Join the mailing list
       url: https://www.listserv.dfn.de/sympa/subscribe/sorsenews
 excerpt: International Series of Online Research Software Events

--- a/_posts/programme/2020-08-19-kickoff.md
+++ b/_posts/programme/2020-08-19-kickoff.md
@@ -22,8 +22,8 @@ two keynote speakers at this event:
 - Dr Kari Jordan, Executive Director, The Carpentries: _I wanna dance with somebody_
 
 The session began with a short welcome and introduction to SORSE followed
-by two 30 minute keynote talks. Dr Mariann Hardey spoke on the subject of
-women in tech and Dr Kari Jordan spoke about the Carpentries. The talks were
+by two 30 minute keynote talks. Dr Kari Jordan spoke about the Carpentries 
+and Dr Mariann Hardey spoke on the subject of women in tech. The talks were
 followed by time for questions and then an opportunity for further discussion
 and networking in breakout rooms.
 

--- a/_posts/programme/2020-08-19-kickoff.md
+++ b/_posts/programme/2020-08-19-kickoff.md
@@ -23,9 +23,11 @@ two keynote speakers at this event:
 
 The session began with a short welcome and introduction to SORSE followed
 by two 30 minute keynote talks. Dr Mariann Hardey spoke on the subject of
-women in tech and Dr Kari Jordan spoke about the Carpentries. Both talks have been recorded. The talks were
+women in tech and Dr Kari Jordan spoke about the Carpentries. The talks were
 followed by time for questions and then an opportunity for further discussion
 and networking in breakout rooms.
+
+<i class="fab fa-fw fa-youtube"></i> A recording of this event is [available on YouTube](https://www.youtube.com/watch?v=2HOznlOCd1w).
 
 ## Mailing list
 A mailing list that will be used only for event updates and notifications is

--- a/_posts/programme/2020-08-19-kickoff.md
+++ b/_posts/programme/2020-08-19-kickoff.md
@@ -14,41 +14,23 @@ registration_url: https://docs.google.com/forms/d/e/1FAIpQLSetlGKtfCxxaAjtHEGxaQ
 meeting_url: https://zoom.us/j/95982897830
 last_modified_at: 2020-09-02
 ---
-To kick our series off, we’re delighted to announce that the SORSE Launch
-Event will take place 13:00-15:00 UTC on Wednesday 2nd September. We’re
-pleased to be welcoming two keynote speakers at this event:
+To kick off our series off, we have run the SORSE Launch
+Event on Wednesday 2nd September. We had
+two keynote speakers at this event:
 
 - Dr Mariann Hardey, Associate Professor, Durham University: _Switching off the label "women in tech"_
 - Dr Kari Jordan, Executive Director, The Carpentries: _I wanna dance with somebody_
 
-<div>
-    {% include registration-button.html %}
-    {% include zoom-button.html %}
-    {% assign time = page.time %}
-    {% include add-to-calendar-button.html %}
-</div>
-
-The session will begin with a short welcome and introduction to SORSE followed
-by two 30 minute keynote talks. Dr Mariann Hardey will speak on the subject of
-women in tech and Dr Kari Jordan will speak about the Carpentries (both
-recorded). Further details and abstracts can be seen below. The talks will be
+The session began with a short welcome and introduction to SORSE followed
+by two 30 minute keynote talks. Dr Mariann Hardey spoke on the subject of
+women in tech and Dr Kari Jordan spoke about the Carpentries. Both talks have been recorded. The talks were
 followed by time for questions and then an opportunity for further discussion
 and networking in breakout rooms.
-
-## Joining instructions
-The event will take place as a Zoom Webinar and will switch to a regular Zoom session for discussion and networking in breakout groups. Connection details
-will be sent to all registered participants in advance of the event.
-
-If you haven't registered, you can still join by clicking the _Join_ button
-above.
 
 ## Mailing list
 A mailing list that will be used only for event updates and notifications is
 available. If you’d like to be notified of upcoming SORSE events, you can join
 the list [here](https://www.listserv.dfn.de/sympa/subscribe/sorsenews).
-
-We hope that many of you will be able to join us for what we’re sure will be
-two interesting and insightful talks on 2nd September.
 
 ## Agenda
 Times in UTC.

--- a/_posts/programme/2020-08-19-kickoff.md
+++ b/_posts/programme/2020-08-19-kickoff.md
@@ -12,7 +12,7 @@ time:
     end: 2020-09-02T15:00:00Z
 registration_url: https://docs.google.com/forms/d/e/1FAIpQLSetlGKtfCxxaAjtHEGxaQ58o360tn9y5BTqHypvc2qnly5CnQ/viewform
 meeting_url: https://zoom.us/j/95982897830
-last_modified_at: 2020-09-02
+last_modified_at: 2020-09-04
 ---
 To kick off our series, we ran the SORSE Launch
 Event on Wednesday 2nd September. We had

--- a/_posts/programme/2020-08-19-kickoff.md
+++ b/_posts/programme/2020-08-19-kickoff.md
@@ -14,7 +14,7 @@ registration_url: https://docs.google.com/forms/d/e/1FAIpQLSetlGKtfCxxaAjtHEGxaQ
 meeting_url: https://zoom.us/j/95982897830
 last_modified_at: 2020-09-02
 ---
-To kick off our series off, we have run the SORSE Launch
+To kick off our series, we ran the SORSE Launch
 Event on Wednesday 2nd September. We had
 two keynote speakers at this event:
 

--- a/_posts/programme/2020-08-19-kickoff.md
+++ b/_posts/programme/2020-08-19-kickoff.md
@@ -28,6 +28,7 @@ followed by time for questions and then an opportunity for further discussion
 and networking in breakout rooms.
 
 <i class="fab fa-fw fa-youtube"></i> A recording of this event is [available on YouTube](https://www.youtube.com/watch?v=2HOznlOCd1w).
+{% include video id="2HOznlOCd1w" provider="youtube" %}
 
 ## Mailing list
 A mailing list that will be used only for event updates and notifications is


### PR DESCRIPTION
This PR is as per https://ukrse.slack.com/archives/GTATB7ATS/p1599122127033300 removing unneeded traces of the kickoff session from the website.

Fixes #311 