### PR TITLE
Handling of join button

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -8,3 +8,7 @@
 {% endif %}
 
 <link href="https://fonts.googleapis.com/css2?family=Karla:wght@400;700&display=swap" rel="stylesheet">
+
+<script>
+  {% include hide-data.js %}
+</script>

--- a/_includes/hide-data.js
+++ b/_includes/hide-data.js
@@ -1,0 +1,8 @@
+document.addEventListener("DOMContentLoaded", function() {
+    const hiding_elements = document.querySelectorAll("[data-hide-at]")
+    for (const element of hiding_elements) {
+        if (element.getAttribute("data-hide-at") < Date.now()) {
+            element.style.display = "none";
+        }
+    }
+});

--- a/_includes/hide-data.js
+++ b/_includes/hide-data.js
@@ -1,7 +1,8 @@
 document.addEventListener("DOMContentLoaded", function() {
     const hiding_elements = document.querySelectorAll("[data-hide-at]")
     for (const element of hiding_elements) {
-        if (element.getAttribute("data-hide-at") < Date.now()) {
+        const timestamp = element.getAttribute("data-hide-at")
+        if (timestamp && timestamp < Date.now()) {
             element.style.display = "none";
         }
     }

--- a/_includes/zoom-button.html
+++ b/_includes/zoom-button.html
@@ -6,7 +6,7 @@
 {{ page.time.last.end | date: '%s' }}
 {% endif %}
 {% endcapture %}
-{% if page.meeting_url %}
+{% if page.meeting_url and event_end > now %}
 <a class="btn btn--success btn--zoom" data-hide-at="{{ event_end | strip }}" href="{{ page.meeting_url }}">
   <i class="fas fa-video"></i> Join
 </a>

--- a/_includes/zoom-button.html
+++ b/_includes/zoom-button.html
@@ -1,7 +1,13 @@
 {% capture now %}{{'now' | date: '%s' %}}{% endcapture %}
-{% capture event_end %}{{ time.end | date: '%s' }}{% endcapture %}
-{% if page.meeting_url and event_end > now %}
-<a class="btn btn--success btn--zoom" data-hide-at="{{ event_end }}" href="{{ page.meeting_url }}">
+{% capture event_end %}
+{% if page.time.end %}
+{{ page.time.end | date: '%s' }}
+{% else %}
+{{ page.time.last.end | date: '%s' }}
+{% endif %}
+{% endcapture %}
+{% if page.meeting_url %}
+<a class="btn btn--success btn--zoom" data-hide-at="{{ event_end | strip }}" href="{{ page.meeting_url }}">
   <i class="fas fa-video"></i> Join
 </a>
 {% endif %}

--- a/_includes/zoom-button.html
+++ b/_includes/zoom-button.html
@@ -1,5 +1,7 @@
-{% if page.meeting_url %}
-<a class="btn btn--success btn--zoom" href="{{ page.meeting_url }}">
+{% capture now %}{{'now' | date: '%s' %}}{% endcapture %}
+{% capture event_end %}{{ time.end | date: '%s' }}{% endcapture %}
+{% if page.meeting_url and event_end > now %}
+<a class="btn btn--success btn--zoom" data-hide-at="{{ event_end }}" href="{{ page.meeting_url }}">
   <i class="fas fa-video"></i> Join
 </a>
 {% endif %}


### PR DESCRIPTION
To give us flexibility to not remove join buttons for each event that has passed, this PR introduces a simple scripts that hides buttons after the events have gone.

This script is currently contained in `_includes` but should maybe go to assets and be loaded as a script and not inline. Waiting on opinions.
Further I don't use any jQuery here, as it currently does not seem to be used on the website.