### PR TITLE
Recording widget in events if available

### DIFF
--- a/_events/talks/event-001.md
+++ b/_events/talks/event-001.md
@@ -21,7 +21,7 @@ time:
 date: 2020-08-19
 meeting_url: https://zoom.us/j/95982897830
 last_modified_at: 2020-09-04
-registration_url: https://docs.google.com/forms/d/e/1FAIpQLSetlGKtfCxxaAjtHEGxaQ58o360tn9y5BTqHypvc2qnly5CnQ/viewform
+registration_url: https://indico.scc.kit.edu/event/904/
 recording_url: https://youtu.be/2HOznlOCd1w?t=623
 ---
 The Carpentries vision is to be the leading inclusive community teaching data and coding skills. Our first lesson program, Software Carpentry, was founded on several core values, including feedback, gratitude, and collaboration. The role research and data plays in your personal and professional life may contribute to your personal values and confidence in working with data. Have you ever considered your journey to data, your personal values, and whether they align? During this talk we will explore your personal journey to data and research, all while contemplating the following: **How do your personal values align with your work as a Research Software Engineer?** This talk is a pulse check. Be prepared to take notes, dig deep, and wrestle with issues of equity, inclusion, and accessibility.

--- a/_events/talks/event-001.md
+++ b/_events/talks/event-001.md
@@ -20,7 +20,8 @@ time:
       end: 2020-09-02T13:50:00Z
 date: 2020-08-19
 meeting_url: https://zoom.us/j/95982897830
-last_modified_at: 2020-09-02
+last_modified_at: 2020-09-04
 registration_url: https://docs.google.com/forms/d/e/1FAIpQLSetlGKtfCxxaAjtHEGxaQ58o360tn9y5BTqHypvc2qnly5CnQ/viewform
+recording_url: https://youtu.be/2HOznlOCd1w?t=623
 ---
 The Carpentries vision is to be the leading inclusive community teaching data and coding skills. Our first lesson program, Software Carpentry, was founded on several core values, including feedback, gratitude, and collaboration. The role research and data plays in your personal and professional life may contribute to your personal values and confidence in working with data. Have you ever considered your journey to data, your personal values, and whether they align? During this talk we will explore your personal journey to data and research, all while contemplating the following: **How do your personal values align with your work as a Research Software Engineer?** This talk is a pulse check. Be prepared to take notes, dig deep, and wrestle with issues of equity, inclusion, and accessibility.

--- a/_events/talks/event-002.md
+++ b/_events/talks/event-002.md
@@ -24,7 +24,7 @@ time:
 date: 2020-08-19
 meeting_url: https://zoom.us/j/95982897830
 last_modified_at: 2020-09-04
-registration_url: https://docs.google.com/forms/d/e/1FAIpQLSetlGKtfCxxaAjtHEGxaQ58o360tn9y5BTqHypvc2qnly5CnQ/viewform
+registration_url: https://indico.scc.kit.edu/event/904/
 recording_url: https://youtu.be/2HOznlOCd1w?t=2849
 ---
 The focus of the talk is on the ways in which women are discursively constructed

--- a/_events/talks/event-002.md
+++ b/_events/talks/event-002.md
@@ -23,8 +23,9 @@ time:
       end: 2020-09-02T14:30:00Z
 date: 2020-08-19
 meeting_url: https://zoom.us/j/95982897830
-last_modified_at: 2020-09-02
+last_modified_at: 2020-09-04
 registration_url: https://docs.google.com/forms/d/e/1FAIpQLSetlGKtfCxxaAjtHEGxaQ58o360tn9y5BTqHypvc2qnly5CnQ/viewform
+recording_url: https://youtu.be/2HOznlOCd1w?t=2849
 ---
 The focus of the talk is on the ways in which women are discursively constructed
 in the context of professional spaces in tech clusters. This is to give time to

--- a/_includes/recording-widget.html
+++ b/_includes/recording-widget.html
@@ -1,0 +1,11 @@
+{% if page.recording_url %}
+{% if page.recording_url contains "youtu.be" or page.recording_url contains "youtube.com" %}
+{% capture video_id %}{{page.recording_url | split: "/" | last }}{% endcapture %}
+{% if video_id contains "?t=" %}
+{% capture id_with_time %}{{ video_id | split: "?" | first }}?start={{ video_id | split: "=" | last }}{% endcapture %}
+{% include video id=id_with_time provider="youtube" %}
+{% else %}
+{% include video id=video_id provider="youtube" %}
+{% endif %}
+{% endif %}
+{% endif %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -16,3 +16,4 @@ layout: single
 <a class="btn btn--success" href="{{ download_link | relative_url }}" target='_blank'>
   <i class="fas fa-file-pdf"></i></i> Download
 </a>
+{% include recording-widget.html %}

--- a/_layouts/event.html
+++ b/_layouts/event.html
@@ -5,6 +5,7 @@ layout: single
 {% include event-summary-long.html event=page %}
 
 {{ content }}
+{% include recording-widget.html %}
 
 <p>
 {% include event-supplements.html %}
@@ -16,4 +17,3 @@ layout: single
 <a class="btn btn--success" href="{{ download_link | relative_url }}" target='_blank'>
   <i class="fas fa-file-pdf"></i></i> Download
 </a>
-{% include recording-widget.html %}


### PR DESCRIPTION
This PR adds a recording widget at the bottom of the events detail page if a `recoding_url` from *youtube* is available. The widget supports adding a specific timestamp to allow for recording of several contributions.