### PR TITLE
Repeated events

### DIFF
--- a/_events/discussions/event-013.md
+++ b/_events/discussions/event-013.md
@@ -22,8 +22,8 @@ affiliations:
     - name: Stanford University, US
       index: 3
 time:
-    - start: 2020-09-16T18:00:00Z
-      end: 2020-09-16T19:30:00Z
+    - - start: 2020-09-16T18:00:00Z
+        end: 2020-09-16T19:30:00Z
 author: *speaker
 category: discussions
 language: English

--- a/_events/software-demos/event-019.md
+++ b/_events/software-demos/event-019.md
@@ -11,8 +11,8 @@ affiliations:
     - name: eLife, UK
       index: 1
 time:
-    - start: 2020-09-09T14:00:00Z
-      end: 2020-09-09T15:00:00Z
+    - - start: 2020-09-09T14:00:00Z
+        end: 2020-09-09T15:00:00Z
 author: *speaker
 category: software-demos
 language: English

--- a/_events/talks/event-001.md
+++ b/_events/talks/event-001.md
@@ -16,8 +16,8 @@ category: talks
 language: English
 author_profile: true
 time:
-    - start: 2020-09-02T13:10:00Z
-      end: 2020-09-02T13:50:00Z
+    - - start: 2020-09-02T13:10:00Z
+        end: 2020-09-02T13:50:00Z
 date: 2020-08-19
 meeting_url: https://zoom.us/j/95982897830
 last_modified_at: 2020-09-04

--- a/_events/talks/event-002.md
+++ b/_events/talks/event-002.md
@@ -19,8 +19,8 @@ category: talks
 language: English
 author_profile: true
 time:
-    - start: 2020-09-02T13:50:00Z
-      end: 2020-09-02T14:30:00Z
+    - - start: 2020-09-02T13:50:00Z
+        end: 2020-09-02T14:30:00Z
 date: 2020-08-19
 meeting_url: https://zoom.us/j/95982897830
 last_modified_at: 2020-09-04

--- a/_events/talks/event-005.md
+++ b/_events/talks/event-005.md
@@ -10,8 +10,8 @@ affiliations:
     - name: University Health Network, Canada
       index: 1
 time:
-    - start: 2020-10-07T16:30:00Z
-      end:  2020-10-07T16:50:00Z
+    - - start: 2020-10-07T16:30:00Z
+        end:  2020-10-07T16:50:00Z
 author: *speaker
 category: talks
 doi: 10.5281/zenodo.3977891

--- a/_events/talks/event-010.md
+++ b/_events/talks/event-010.md
@@ -19,8 +19,8 @@ affiliations:
     - name: Information Sciences Institute, USC, US
       index: 1
 time:
-    - start: 2020-09-22T19:30:00Z
-      end: 2020-09-22T20:00:00Z
+    - - start: 2020-09-22T19:30:00Z
+        end: 2020-09-22T20:00:00Z
 author: *speaker
 category: talks
 doi: 10.5281/zenodo.3977916

--- a/_events/talks/event-012.md
+++ b/_events/talks/event-012.md
@@ -9,8 +9,8 @@ authors:
     - name: Prof. Mark Mon-Williams
     - name: Dr. Faisal Mushtaq
 time:
-    - start: 2020-09-22T19:00:00Z
-      end: 2020-09-22T19:30:00Z
+    - - start: 2020-09-22T19:00:00Z
+        end: 2020-09-22T19:30:00Z
 author: *speaker
 doi: 10.5281/zenodo.3977920
 category: talks

--- a/_events/talks/event-014.md
+++ b/_events/talks/event-014.md
@@ -10,8 +10,8 @@ affiliations:
     - name: Teri Apps
       index: 1
 time:
-    - start: 2020-10-16T09:30:00Z
-      end: 2020-10-16T10:00:00Z
+    - - start: 2020-10-16T09:30:00Z
+        end: 2020-10-16T10:00:00Z
 author: *speaker
 category: talks
 language: English

--- a/_events/talks/event-018.md
+++ b/_events/talks/event-018.md
@@ -9,8 +9,8 @@ affiliations:
     - name: The Numerical Algorithms Group (NAG)
       index: 1
 time:
-    - start: 2020-10-16T09:00:00Z
-      end: 2020-10-16T09:30:00Z
+    - - start: 2020-10-16T09:00:00Z
+        end: 2020-10-16T09:30:00Z
 author: *speaker
 category: talks
 language: English

--- a/_events/talks/event-020.md
+++ b/_events/talks/event-020.md
@@ -11,8 +11,8 @@ affiliations:
     - name: Harvard University, US
       index: 1
 time:
-    - start: 2020-10-07T16:00:00Z
-      end: 2020-10-07T16:30:00Z
+    - - start: 2020-10-07T16:00:00Z
+        end: 2020-10-07T16:30:00Z
 author: *speaker
 category: talks
 language: english

--- a/_includes/event-summary-long.html
+++ b/_includes/event-summary-long.html
@@ -55,12 +55,12 @@
 </div>
 
 {% if event.time %}
-{% for slot in event.time %}
+{% for occurrence in event.time %}
 {% if forloop.index0 == 1 %}
-<b>Further slots:</b>
+<b>Further occurrences:</b>
 {% endif %}
 <ul class="page__date">
-  {% for time in slot %}
+  {% for time in occurrence %}
     <li>
       {% include event-time.html %}
     </li>

--- a/_includes/event-summary-long.html
+++ b/_includes/event-summary-long.html
@@ -55,13 +55,18 @@
 </div>
 
 {% if event.time %}
+{% for slot in event.time %}
+{% if forloop.index0 == 1 %}
+<b>Further slots:</b>
+{% endif %}
 <ul class="page__date">
-  {% for time in event.time %}
-  <li>
-    {% include event-time.html %}
-  </li>
+  {% for time in slot %}
+    <li>
+      {% include event-time.html %}
+    </li>
   {% endfor %}
 </ul>
+{% endfor %}
 <sup><a href="{{ site.shared_calendar }}" class="footnote">Subscribe to all SORSE events</a></sup>
 {% else %}
 <div class="notice--info" style="display: table-cell;"><i>This event will be scheduled soon</i></div>

--- a/_includes/event-summary.html
+++ b/_includes/event-summary.html
@@ -6,13 +6,18 @@
   <b>{{ author.name }}</b>{% unless forloop.last %}, {% endunless %}
 {% endfor %}
 {% if event.time %}
+{% for slot in event.time %}
+{% if forloop.index0 == 1 %}
+<b>Further slots</b>
+{% endif %}
 <ul class="page__date">
-  {% for time in event.time %}
+  {% for time in slot %}
   <li>
     {% include event-time.html no_button=true%}
   </li>
   {% endfor %}
 </ul>
+{% endfor %}
 {% else %}
 <div class="notice--info" style="display: table-cell;"><i>This event will be scheduled soon</i></div>
 {% endif %}

--- a/_includes/event-summary.html
+++ b/_includes/event-summary.html
@@ -6,12 +6,12 @@
   <b>{{ author.name }}</b>{% unless forloop.last %}, {% endunless %}
 {% endfor %}
 {% if event.time %}
-{% for slot in event.time %}
+{% for occurrence in event.time %}
 {% if forloop.index0 == 1 %}
-<b>Further slots</b>
+<b>Further occurrences</b>
 {% endif %}
 <ul class="page__date">
-  {% for time in slot %}
+  {% for time in occurrence %}
   <li>
     {% include event-time.html no_button=true%}
   </li>

--- a/_includes/event.js
+++ b/_includes/event.js
@@ -1,5 +1,5 @@
 {%- assign occurrence_name = "" -%}
-{%- for slot in post.time -%}
+{%- for occurrence in post.time -%}
 {%- if forloop.index > 1 -%}
   {%- capture occurrence_name %} (occurrence #{{ forloop.index }}){% endcapture -%}
 {%- endif -%}

--- a/_includes/event.js
+++ b/_includes/event.js
@@ -1,6 +1,12 @@
-{%- for time in post.time -%}
+{%- assign slot_name = "" -%}
+{%- for slot in post.time -%}
+{%- if forloop.index > 1 -%}
+  {%- capture slot_name %} (slot #{{ forloop.index }}){% endcapture -%}
+{%- endif -%}
+{%- assign is_last = forloop.last -%}
+{%- for time in slot -%}
 {
-  title  : "{{ post.title }}{% unless forloop.first %} (continued){% endunless %}",
+  title  : "{{ post.title }}{{ slot_name }}{% unless forloop.first %} (continued){% endunless %}",
   {%- if include.onclick == 'tag' %}
   {%- if post.id %}
   url    : "#{{ post.id | split: '/' | last }}",
@@ -16,5 +22,6 @@
   classNames: ["fc-sorse-event"],
   {% unless time.end %}// {% endunless %}end    : '{{ time.end | date_to_xmlschema }}',
   start  : '{{ time.start | date_to_xmlschema }}'
-}{% unless forloop.last %},{% endunless %}
+}{% unless forloop.last and is_last %},{% endunless %}
+{%- endfor -%}
 {%- endfor -%}

--- a/_includes/event.js
+++ b/_includes/event.js
@@ -1,12 +1,12 @@
-{%- assign slot_name = "" -%}
+{%- assign occurrence_name = "" -%}
 {%- for slot in post.time -%}
 {%- if forloop.index > 1 -%}
-  {%- capture slot_name %} (slot #{{ forloop.index }}){% endcapture -%}
+  {%- capture occurrence_name %} (occurrence #{{ forloop.index }}){% endcapture -%}
 {%- endif -%}
 {%- assign is_last = forloop.last -%}
-{%- for time in slot -%}
+{%- for time in occurrence -%}
 {
-  title  : "{{ post.title }}{{ slot_name }}{% unless forloop.first %} (continued){% endunless %}",
+  title  : "{{ post.title }}{{ occurrence_name }}{% unless forloop.first %} (continued){% endunless %}",
   {%- if include.onclick == 'tag' %}
   {%- if post.id %}
   url    : "#{{ post.id | split: '/' | last }}",

--- a/_includes/zoom-button.html
+++ b/_includes/zoom-button.html
@@ -1,9 +1,7 @@
 {% capture now %}{{'now' | date: '%s' %}}{% endcapture %}
 {% capture event_end %}
-{% if page.time.end %}
-{{ page.time.end | date: '%s' }}
-{% else %}
-{{ page.time.last.end | date: '%s' }}
+{% if page.time %}
+{{ page.time.last.last.end | date: '%s' }}
 {% endif %}
 {% endcapture %}
 {% if page.meeting_url and event_end > now %}

--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -76,6 +76,9 @@ layout: single
          $(".card").hide();
          elem.show();
        }
+     },
+     eventDidMount: function(arg) {
+       arg.el.setAttribute("title", arg.event.title);
      }
    });
   calendar.render();


### PR DESCRIPTION
This PR implements the functionality to display repeated events on the website, as it has been discussed in former issues and PRs. 

Times need now to be inserted like in #275. 

In summary: I

- updated the `time` in the yaml frontmatter of all existing events,
- adapted the cards which now look like
  ![image](https://user-images.githubusercontent.com/9960249/92527843-fff34200-f227-11ea-94f2-6af6022e8b75.png)
- adapted the event pages which now look like
  ![image](https://user-images.githubusercontent.com/9960249/92527877-0e415e00-f228-11ea-8a06-733798bc58c7.png)
- labeled repeated events  with `(slot #i)`, such as in
  ![image](https://user-images.githubusercontent.com/9960249/92527820-f2d65300-f227-11ea-88fc-bc3409d5d965.png)
- and I take the new structure into account for the zoom-button (3799a99c236ad0e99c00fbb8002f7f0d8c048d52).

This multiple lists might not be the most elegant solution, but it is the easiest to implement (and I am a bit short in time, at the moment). Comments are highly welcomed!

Previews are available here:

- [Workshops in the programme page](https://1139-267395254-gh.circle-artifacts.com/0/SORSE/programme/index.html#workshops)
- [event page with multiple slots](https://1139-267395254-gh.circle-artifacts.com/0/SORSE/programme/workshops/event-017/index.html)

closes #275  