### PR TITLE
Multiple registration urls

### DIFF
--- a/_events/workshops/event-017.md
+++ b/_events/workshops/event-017.md
@@ -33,8 +33,8 @@ prerequisites: "no specific knowledge/skills required"
 date: 2020-08-18
 last_modified_at: 2020-09-08
 registration_url:
-    - https://indico.scc.kit.edu/event/923/
-    - https://indico.scc.kit.edu/event/922/
+    - https://indico.scc.kit.edu/event/924/
+    - https://indico.scc.kit.edu/event/925/
 ---
 Research Software Engineering (RSE) is increasingly being established as a field and profession in its own right. Since the term was coined about a decade ago, RSE has also been the subject of empirical research to gain knowledge and evidence about the various aspects involved. For example, the 2017 "State of the Nation Report" by Alys Brett et al. (https://doi.org/10.5281/zenodo.495360) presents survey data about the demographics of UK-based RSEs, and Rotem Botvinik-Nezer et al. (https://doi.org/10.1038/s41586-020-2314-9) report on the extreme variability of results they found when they let many teams develop analysis programs for the same dataset. Such findings are the basis for the international RSE community to provide support and develop solutions for open problems.
 

--- a/_events/workshops/event-017.md
+++ b/_events/workshops/event-017.md
@@ -32,6 +32,9 @@ time:
 prerequisites: "no specific knowledge/skills required"
 date: 2020-08-18
 last_modified_at: 2020-09-08
+registration_url:
+    - https://indico.scc.kit.edu/event/923/
+    - https://indico.scc.kit.edu/event/922/
 ---
 Research Software Engineering (RSE) is increasingly being established as a field and profession in its own right. Since the term was coined about a decade ago, RSE has also been the subject of empirical research to gain knowledge and evidence about the various aspects involved. For example, the 2017 "State of the Nation Report" by Alys Brett et al. (https://doi.org/10.5281/zenodo.495360) presents survey data about the demographics of UK-based RSEs, and Rotem Botvinik-Nezer et al. (https://doi.org/10.1038/s41586-020-2314-9) report on the extreme variability of results they found when they let many teams develop analysis programs for the same dataset. Such findings are the basis for the international RSE community to provide support and develop solutions for open problems.
 

--- a/_includes/event-summary-long.html
+++ b/_includes/event-summary-long.html
@@ -57,7 +57,7 @@
 {% if event.time %}
 {% for occurrence in event.time %}
 {% if forloop.index0 == 1 %}
-<b>Further occurrences:</b>
+<b>Repeated events</b> <abbr title="This event is repeated to cover multiple time zones"><i class="fas fa-info-circle"></i></abbr>
 {% endif %}
 <ul class="page__date">
   {% for time in occurrence %}

--- a/_includes/event-summary.html
+++ b/_includes/event-summary.html
@@ -8,7 +8,7 @@
 {% if event.time %}
 {% for occurrence in event.time %}
 {% if forloop.index0 == 1 %}
-<b>Further occurrences</b>
+<b>Repeated events</b> <abbr title="This event is repeated to cover multiple time zones"><i class="fas fa-info-circle"></i></abbr>
 {% endif %}
 <ul class="page__date">
   {% for time in occurrence %}

--- a/_includes/registration-button.html
+++ b/_includes/registration-button.html
@@ -1,7 +1,16 @@
 {% if page.registration_url %}
+{% if page.registration_url[0] %}
+<select class="btn btn--success registration-menu" >
+    <option value="" selected disabled hidden>&#xf56b; Register</option>
+    {% for uri in page.registration_url %}
+        <option value="{{ uri }}">Occurence #{{ forloop.index }}</option>
+    {% endfor %}
+</select>
+{% else %}
 <a class="btn btn--success" href="{{ page.registration_url }}">
   <i class="fas fa-feather-alt"></i> Register
 </a>
+{% endif %}
 {% else %}
 <span class="notice--info">
   <i>Registration will open soon</i>

--- a/_includes/registration-button.html
+++ b/_includes/registration-button.html
@@ -1,10 +1,15 @@
 {% if page.registration_url %}
 {% if page.registration_url[0] %}
-<select class="btn btn--success registration-menu" >
-    <option value="" selected disabled hidden>&#xf56b; Register</option>
-    {% for uri in page.registration_url %}
-        <option value="{{ uri }}">Occurence #{{ forloop.index }}</option>
-    {% endfor %}
+<select class="btn btn--success registration-menu" onchange="if (this.value) window.location.href=this.value">
+    <option value="" selected disabled hidden >&#xf56b; Register</option>
+    {% for uri in page.registration_url -%}
+        {%- if forloop.index0 > 0 %}
+            {%- assign label = "Repetition on " %}
+        {%- else %}
+            {%- assign label = "Premiere on " %}
+        {%- endif -%}
+        <option value="{{ uri }}">{{ label }}{{ page.time[forloop.index0][0].start | date: "%B %-d, %Y" }}</option>
+    {% endfor -%}
 </select>
 {% else %}
 <a class="btn btn--success" href="{{ page.registration_url }}">

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -288,3 +288,17 @@ html {
 .events-sidebar {
   padding-top: 2em;
 }
+
+select.registration-menu {
+  font-family: 'Font Awesome 5 Free', 'sans-serif';
+  text-align: left;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  /* Some browsers will not display the caret when using calc, so we put the fallback first */
+  background: url('data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="caret-down" class="svg-inline--fa fa-caret-down fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="white" d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"></path></svg>') $btn-success-color no-repeat calc(100% - 10px) !important;
+
+  &:hover {
+      background: url('data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="caret-down" class="svg-inline--fa fa-caret-down fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="white" d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"></path></svg>') $btn-success-color-hover no-repeat calc(100% - 10px) !important;
+  }
+}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -295,6 +295,7 @@ select.registration-menu {
   -webkit-appearance: none;
   -moz-appearance: none;
   appearance: none;
+  max-width: 200px;
   /* Some browsers will not display the caret when using calc, so we put the fallback first */
   background: url('data:image/svg+xml;utf8,<svg aria-hidden="true" focusable="false" data-prefix="fas" data-icon="caret-down" class="svg-inline--fa fa-caret-down fa-w-10" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 512"><path fill="white" d="M31.3 192h257.3c17.8 0 26.7 21.5 14.1 34.1L174.1 354.8c-7.8 7.8-20.5 7.8-28.3 0L17.2 226.1C4.6 213.5 13.5 192 31.3 192z"></path></svg>') $btn-success-color no-repeat calc(100% - 10px) !important;
 


### PR DESCRIPTION
@eileen-kuehn, this PR allows multiple registration urls. If you enter the registration urls as

```yaml
registration_url:
    - https://indico.scc.kit.edu/event/923/
    - https://indico.scc.kit.edu/event/922/
```

the button becomes a dropdown menu

![image](https://user-images.githubusercontent.com/9960249/92611239-e2ba8400-f2b8-11ea-878e-162de659ed46.png)

We can do better than that for sure, but it does the job at the moment

- [x] revert e261e83dfd23f72bf303cefca7c507d1eb8ac71c