### PR TITLE
Fix event list

### DIFF
--- a/_data/event_complements.yml
+++ b/_data/event_complements.yml
@@ -1,16 +1,16 @@
 # custom events that should appear in the calendar
 - title: SORSE Kickoff Welcoming Words
   time:
-      - start: 2020-09-02T13:00:00Z
-        end: 2020-09-02T13:10:00Z
+      - - start: 2020-09-02T13:00:00Z
+          end: 2020-09-02T13:10:00Z
   category: event complements
   complements:
       - event-001
       - event-002
 - title: SORSE Kickoff Discussion and Networking
   time:
-      - start: 2020-09-02T14:30:00Z
-        end: 2020-09-02T15:00:00Z
+      - - start: 2020-09-02T14:30:00Z
+          end: 2020-09-02T15:00:00Z
   category: event complements
   complements:
       - event-001

--- a/_includes/upcoming-events.html
+++ b/_includes/upcoming-events.html
@@ -26,17 +26,25 @@
      {%- endif -%}
    ];
 
-   events = events.filter(e => new Date(e.start) >= new Date());
    events.sort((e1, e2) => new Date(e1.start) - new Date(e2.start));
 
    calendar = new FullCalendar.Calendar(calendarEl, {
      headerToolbar: false,
      aspectRatio: 2,
      noEventsContent: "No upcoming events",
-     initialView: 'listYear',
+     initialView: 'listAll',
      editable: true,
      selectable: true,
-     events: events
+     events: events,
+     views: {
+       listAll: {
+         type: "list",
+         visibleRange: {
+           start: new Date(),
+           end: "2021-12-31"
+         }
+       }
+     }
    });
   calendar.render();
 });

--- a/_layouts/calendar.html
+++ b/_layouts/calendar.html
@@ -27,11 +27,19 @@ layout: single
  document.addEventListener('DOMContentLoaded', function() {
    var calendarEl = document.getElementById('calendar');
 
+   events = [
+     {% include ask-us-anything.js onclick='tag' %},
+     {% include cfc-deadlines.js background=true onclick='tag' %},
+     {% include events.js onclick='tag' %}
+   ];
+
+   events.sort((e1, e2) => new Date(e1.start) - new Date(e2.start));
+
    calendar = new FullCalendar.Calendar(calendarEl, {
      headerToolbar: {
        left: 'prev,next today',
        center: 'title',
-       right: 'dayGridMonth,timeGridWeek,timeGridDay,listYear'
+       right: 'dayGridMonth,timeGridWeek,timeGridDay,listAll'
      },
      buttonText: {
        week: 'week',
@@ -64,11 +72,16 @@ layout: single
      //
      slotDuration: "00:15",
      dayMaxEvents: true, // allow "more" link when too many events
-     events: [
-        {% include ask-us-anything.js onclick='tag' %},
-        {% include cfc-deadlines.js background=true onclick='tag' %},
-        {% include events.js onclick='tag' %}
-     ],
+     events: events,
+     views: {
+       listAll: {
+         type: "list",
+         visibleRange: {
+           start: events[0].start,
+           end: events[events.length-1].end
+         }
+       }
+     },
      eventClick: function(info) {
        info.jsEvent.preventDefault(); // don't let the browser navigate
        var elem = $(info.event.url);

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -30,6 +30,10 @@ This is an open call to all RSEs and anyone involved with research software worl
 
 Any questions, read [more](faq/about/what-is-sorse), [get in touch](contact/), or see [upcoming events](#upcoming-events)!
 
+## Upcoming Events
+
+{% include upcoming-events.html all=true %}
+
 ## News
 
 {% if paginator %}
@@ -43,7 +47,3 @@ Any questions, read [more](faq/about/what-is-sorse), [get in touch](contact/), o
 {% endfor %}
 
 {% include paginator.html %}
-
-## Upcoming Events
-
-{% include upcoming-events.html all=true %}


### PR DESCRIPTION
This PR makes sure that all events are shown in list calendars, not only the ones in 2020, and it puts the _Upcoming events_ higher on the landing page.

closes #346, closes #391 