### PR TITLE
Remove second author from event-015

### DIFF
--- a/_events/talks/event-015.md
+++ b/_events/talks/event-015.md
@@ -5,13 +5,9 @@ authors:
       name: Dr. Rizwan Malik
       is_speaker: true
       affiliation: 1
-    - name: Shoaib Sufi
-      affiliation: 2
 affiliations:
     - name: Bolton NHS Foundation Trust, UK
       index: 1
-    - name: eScience Lab, University of Manchester, UK
-      index: 2
 author: *speaker
 category: talks
 language: English


### PR DESCRIPTION
The second author from this event has been in touch to say they will no longer be involved and asking to be removed from the web pages.

This is ready to merge.