### PR TITLE
list lightning talks on the lightning talks post

### DIFF
--- a/_events/panels/event-035.md
+++ b/_events/panels/event-035.md
@@ -23,7 +23,7 @@ category: panels
 date: 2021-01-13
 doi: 10.5281/zenodo.4439258
 language: English
-last_modified_at: '2021-01-14'
+last_modified_at: 2021-01-14
 panelists:
 - Adrian Harwood, University of Manchester, leads mobile development efforts in his
   RSE group.

--- a/_events/posters/event-036.md
+++ b/_events/posters/event-036.md
@@ -101,6 +101,9 @@ doi: 10.5281/zenodo.4430849
 language: English
 last_modified_at: 2021-01-10
 title: Code Review Community
+time:
+  - - start: 2021-01-20T15:00:00Z
+    - end: 2021-01-20T16:00:00Z
 ---
 
 Code review for research software is the process by which peers evaluate each other's source code. This involves checking that the code does what it claims and is written in a way that can easily be read, maintained, and built upon. Code review is an important tool for ensuring that software is high-quality and reusable, and should be a widely-adopted "best practice".

--- a/_events/posters/event-036.md
+++ b/_events/posters/event-036.md
@@ -103,7 +103,7 @@ last_modified_at: 2021-01-10
 title: Code Review Community
 time:
   - - start: 2021-01-20T15:00:00Z
-    - end: 2021-01-20T16:00:00Z
+      end: 2021-01-20T16:00:00Z
 ---
 
 Code review for research software is the process by which peers evaluate each other's source code. This involves checking that the code does what it claims and is written in a way that can easily be read, maintained, and built upon. Code review is an important tool for ensuring that software is high-quality and reusable, and should be a widely-adopted "best practice".

--- a/_events/posters/event-040.md
+++ b/_events/posters/event-040.md
@@ -13,7 +13,7 @@ category: posters
 date: 2021-01-13
 doi: 10.5281/zenodo.4439266
 language: English
-last_modified_at: '2021-01-14'
+last_modified_at: 2021-01-14
 title: Four pillars of a reproducible PhD
 time:
   - - start: 2021-01-20T15:00:00Z

--- a/_events/posters/event-040.md
+++ b/_events/posters/event-040.md
@@ -17,7 +17,7 @@ last_modified_at: '2021-01-14'
 title: Four pillars of a reproducible PhD
 time:
   - - start: 2021-01-20T15:00:00Z
-    - end: 2021-01-20T16:00:00Z
+      end: 2021-01-20T16:00:00Z
 ---
 
 Reproducibility and sustainability of research and associated software are increasingly viewed as priorities by publishers, funders and the academic community. The process of writing a thesis can be a playground where modern PhD students can explore new tools and techniques for improving the reproducibility and sustainability of their research, however the number of possible tools is vast and potentially overwhelming. This talk and associated blog post present the author's personal opinion on the four underpinning elements of a reproducible PhD: version control, automation, open publishing and sustainable software; and describes specific tools and principles used in the production of the author's thesis. This description may offer a template for future students wishing to perform reproducible research.

--- a/_events/posters/event-040.md
+++ b/_events/posters/event-040.md
@@ -15,6 +15,9 @@ doi: 10.5281/zenodo.4439266
 language: English
 last_modified_at: '2021-01-14'
 title: Four pillars of a reproducible PhD
+time:
+  - - start: 2021-01-20T15:00:00Z
+    - end: 2021-01-20T16:00:00Z
 ---
 
 Reproducibility and sustainability of research and associated software are increasingly viewed as priorities by publishers, funders and the academic community. The process of writing a thesis can be a playground where modern PhD students can explore new tools and techniques for improving the reproducibility and sustainability of their research, however the number of possible tools is vast and potentially overwhelming. This talk and associated blog post present the author's personal opinion on the four underpinning elements of a reproducible PhD: version control, automation, open publishing and sustainable software; and describes specific tools and principles used in the production of the author's thesis. This description may offer a template for future students wishing to perform reproducible research.

--- a/_events/posters/event-041.md
+++ b/_events/posters/event-041.md
@@ -18,7 +18,7 @@ prerequisites: Knowledge of APIs and web development practises would be helpful 
 title: Embedding a Jupyter Notebook
 time:
   - - start: 2021-01-20T15:00:00Z
-    - end: 2021-01-20T16:00:00Z
+      end: 2021-01-20T16:00:00Z
 ---
 
 Many RSEs and researchers are familiar with using Jupyter Notebooks to analyse data and output results, but how can this functionality be included within a larger platform or application? Creating a new analysis tool would take a lot of developer hours, and so a more cost-effective solution could be to embed Jupyter within your application.

--- a/_events/posters/event-041.md
+++ b/_events/posters/event-041.md
@@ -16,6 +16,9 @@ last_modified_at: '2021-01-14'
 prerequisites: Knowledge of APIs and web development practises would be helpful but
   not necessary.
 title: Embedding a Jupyter Notebook
+time:
+  - - start: 2021-01-20T15:00:00Z
+    - end: 2021-01-20T16:00:00Z
 ---
 
 Many RSEs and researchers are familiar with using Jupyter Notebooks to analyse data and output results, but how can this functionality be included within a larger platform or application? Creating a new analysis tool would take a lot of developer hours, and so a more cost-effective solution could be to embed Jupyter within your application.

--- a/_events/posters/event-041.md
+++ b/_events/posters/event-041.md
@@ -12,7 +12,7 @@ category: posters
 date: 2021-01-13
 doi: 10.5281/zenodo.4439264
 language: English
-last_modified_at: '2021-01-14'
+last_modified_at: 2021-01-14
 prerequisites: Knowledge of APIs and web development practises would be helpful but
   not necessary.
 title: Embedding a Jupyter Notebook

--- a/_events/talks/event-025.md
+++ b/_events/talks/event-025.md
@@ -19,6 +19,9 @@ language: English
 last_modified_at: 2021-01-14
 prerequisites: All experience levels are welcome.
 title: Development of an Automated High-Throughput Animal Training Platform
+time:
+  - - start: 2021-01-20T15:00:00Z
+    - end: 2021-01-20T16:00:00Z
 ---
 
 In traditional neuroscience laboratory research, training animals to execute sensorimotor tasks is time consuming, labor and resource intensive, and prone to human bias and error.  The Research Software Engineering team at Harvard University's Faculty of Arts and Science Research Computing (FASRC) has developed an automated training system pipeline that standardizes and automates animal training.  The pipeline consists of Teensy microcontrollers that monitor animal training events, RaspberryPis that orchestrate and log training instructions, PiCameras that record subjects, and open-source software, including a Vue web interface, a Flask server, and a PostGreSQL database.

--- a/_events/talks/event-025.md
+++ b/_events/talks/event-025.md
@@ -12,11 +12,11 @@ authors:
 - *id001
 - affiliation: 1
   name: Mahmood Shad
-category: talks
+category: posters
 date: 2020-09-09
 doi: 10.5281/zenodo.4430821
 language: English
-last_modified_at: 2021-01-10
+last_modified_at: 2021-01-14
 prerequisites: All experience levels are welcome.
 title: Development of an Automated High-Throughput Animal Training Platform
 ---

--- a/_events/talks/event-025.md
+++ b/_events/talks/event-025.md
@@ -21,7 +21,7 @@ prerequisites: All experience levels are welcome.
 title: Development of an Automated High-Throughput Animal Training Platform
 time:
   - - start: 2021-01-20T15:00:00Z
-    - end: 2021-01-20T16:00:00Z
+      end: 2021-01-20T16:00:00Z
 ---
 
 In traditional neuroscience laboratory research, training animals to execute sensorimotor tasks is time consuming, labor and resource intensive, and prone to human bias and error.  The Research Software Engineering team at Harvard University's Faculty of Arts and Science Research Computing (FASRC) has developed an automated training system pipeline that standardizes and automates animal training.  The pipeline consists of Teensy microcontrollers that monitor animal training events, RaspberryPis that orchestrate and log training instructions, PiCameras that record subjects, and open-source software, including a Vue web interface, a Flask server, and a PostGreSQL database.

--- a/_posts/programme/2020-12-01-lightning-talk-session.md
+++ b/_posts/programme/2020-12-01-lightning-talk-session.md
@@ -13,7 +13,7 @@ id: 1
 include_in_calendar: true
 time:
   - - start: 2021-01-20T15:00:00Z
-    - end: 2021-01-20T16:00:00Z
+      end: 2021-01-20T16:00:00Z
 ---
 
 We will run a lightning talk session on Wed 20th January 2021 at 3pm UTC.  The session will be a one hour slot and include up to 10  lightning talks. Each lightning talk should be supported by either a poster or a blog post.

--- a/_posts/programme/2020-12-01-lightning-talk-session.md
+++ b/_posts/programme/2020-12-01-lightning-talk-session.md
@@ -35,3 +35,9 @@ Presenters will be asked to pre-record a 1 to 2 minute lightning talk which will
 * lightning talk session - pre-record talk 1-2 minutes
 * followed by breakout session
 
+## Lightning talks
+
+{%- assign posts = site.events | where: "category", "posters" -%}
+{%- for post in posts -%}
+{% include event-card.html %}
+{%- endfor -%}


### PR DESCRIPTION
This PR adds cards of the posters for the lightning talk session on January, 20, changes event-025 to the posters category (the URL will still be the same), and adds the times to the poster events. 