### PR TITLE
Remove event-040 from the lightning talks session

### DIFF
--- a/_events/posters/event-040.md
+++ b/_events/posters/event-040.md
@@ -15,9 +15,6 @@ doi: 10.5281/zenodo.4439266
 language: English
 last_modified_at: 2021-01-14
 title: Four pillars of a reproducible PhD
-time:
-  - - start: 2021-01-20T15:00:00Z
-      end: 2021-01-20T16:00:00Z
 ---
 
 Reproducibility and sustainability of research and associated software are increasingly viewed as priorities by publishers, funders and the academic community. The process of writing a thesis can be a playground where modern PhD students can explore new tools and techniques for improving the reproducibility and sustainability of their research, however the number of possible tools is vast and potentially overwhelming. This talk and associated blog post present the author's personal opinion on the four underpinning elements of a reproducible PhD: version control, automation, open publishing and sustainable software; and describes specific tools and principles used in the production of the author's thesis. This description may offer a template for future students wishing to perform reproducible research.

--- a/_posts/programme/2020-12-01-lightning-talk-session.md
+++ b/_posts/programme/2020-12-01-lightning-talk-session.md
@@ -39,5 +39,7 @@ Presenters will be asked to pre-record a 1 to 2 minute lightning talk which will
 
 {%- assign posts = site.events | where: "category", "posters" -%}
 {%- for post in posts -%}
+{%- if post.time and post.time[0][0].start == page.time[0][0].start -%}
 {% include event-card.html %}
+{%- endif -%}
 {%- endfor -%}


### PR DESCRIPTION
this PR removes https://sorse.github.io/programme/posters/event-040/ from the lightning talks session.