### PR TITLE
Typo fixed in finale event agenda

### DIFF
--- a/_posts/programme/2021-03-24-finale.md
+++ b/_posts/programme/2021-03-24-finale.md
@@ -36,7 +36,7 @@ All times in UTC.
 
 - **16:00**: Welcome and introduction to the event
 
-  *Sandra Gesing*, __University of Notre Dame_
+  Sandra Gesing, _University of Notre Dame_
 
 - **16:05**: The International Council of RSE Associations
 


### PR DESCRIPTION
Minor typo fix in the agenda for the finale event - ready to merge.