### PR TITLE
Redirect final to finale/

### DIFF
--- a/_pages/redirect_final.html
+++ b/_pages/redirect_final.html
@@ -1,0 +1,18 @@
+---
+permalink: /programme/final/
+redirect: /programme/finale/
+---
+<html>
+  <head>
+      <meta charset="utf-8"/>
+      <meta http-equiv="refresh" content="1;url={{ page.redirect | relative_url }}"/>
+      <link rel="canonical" href="{{ page.redirect | relative_url }}"/>
+      <script type="text/javascript">
+              window.location.href = "{{ page.redirect | relative_url }}"
+      </script>
+      <title>Page Redirection</title>
+  </head>
+  <body>
+    If you are not redirected automatically, follow <a href='{{ page.redirect | relative_url }}'>this link</a>.
+  </body>
+</html>

--- a/_posts/programme/2021-03-24-finale.md
+++ b/_posts/programme/2021-03-24-finale.md
@@ -1,7 +1,7 @@
 ---
 title: "The SORSE Finale"
 category: news
-permalink: /programme/final/
+permalink: /programme/finale/
 tags:
   - announcement
 sidebar:


### PR DESCRIPTION
because the URL should be `/programme/finale/`, rather than `/programme/final/`. But the old one is still working and just redirects to the new one