### PR TITLE
Cleanup after SORSE final

### DIFF
--- a/_layouts/programme-team.html
+++ b/_layouts/programme-team.html
@@ -11,15 +11,6 @@ layout: single
   {% include faq-cards-tag.html tag=tag title="FAQ" %}
 {% endunless %}
 
-{% if page.fullcalendar %}
-{%- assign events = site.events | where: "category", page.team -%}
-{%- if events.size > 0 -%}
-<h2 id="upcoming-events">Upcoming events</h2>
-
-{% include upcoming-events.html category=page.team %}
-{%- endif -%}
-{% endif %}
-
 <h2 id="team">Team</h2>
 
 {% include team-members.html team=page.team %}

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -27,8 +27,7 @@ on March 24th 2021. Thanks to all the contributors who submitted abstracts and
 gave presentations, discussions, demonstrations, and thanks to everyone who
 participated in one of our sessions to make all of this possible.
 
-But this won't be the end of everything. There is still need for exchange
-within our international community of research software engineers.
+But this isn't the end. There is still a need for knowledge exchange and networking within our international community of Research Software Engineers.
 
 Stay tuned and keep an eye on the communication channels of
 [your national RSE chapter]({{ "/contact/chapters/" | relative_url }}).

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -35,7 +35,7 @@ Stay tuned and keep an eye on the communication channels of
 
 Welcome to SORSE - A **S**eries of **O**nline **R**esearch **S**oftware **E**vents - our international answer to the COVID-19-induced cancellation of many national RSE conferences. We want to provide an opportunity for RSEs to develop and grow their skills, build new collaborations and engage with RSEs worldwide.
 
-This series has been an open call to all RSEs and anyone involved with research software worldwide, to propose a talk, a workshop, a software demo, a panel or discussion, blog post or poster. After each event, SORSE did provide an opportunity for networking and informal discussion with other participants in small groups.
+This series has been an open call to all RSEs and anyone involved with research software worldwide, to propose a talk, a workshop, a software demo, a panel or discussion, blog post or poster. After many of our events, SORSE provided an opportunity for networking and informal discussion with other participants in small groups.
 
 <div class="notice--info">
   {{ final-notice | markdownify }}

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -21,9 +21,26 @@ excerpt: International Series of Online Research Software Events
     {% include twitter.html %}
 </aside>
 
+{% capture final-notice %}
+SORSE ended with it's [final event]({{ "/programme/finale/" | relative_url }})
+on March 24th. 2021. Thanks to all the contributors that submitted abstracts and
+gave presentations, discussions, demonstrations, and thanks to everyone who
+participated in one of our sessions to make all of this possible.
+
+But this won't be the end of everything. There is still need for exchange
+within our emerging community of international research software engineers.
+
+Stay tuned and keep an eye on the communication channels of
+[your national RSE chapter]({{ "/contact/chapters/" | relative_url }}).
+{% endcapture %}
+
 Welcome to SORSE - A **S**eries of **O**nline **R**esearch **S**oftware **E**vents - our international answer to the COVID-19-induced cancellation of many national RSE conferences. We want to provide an opportunity for RSEs to develop and grow their skills, build new collaborations and engage with RSEs worldwide.
 
 This series has been an open call to all RSEs and anyone involved with research software worldwide, to propose a talk, a workshop, a software demo, a panel or discussion, blog post or poster. After each event, SORSE did provide an opportunity for networking and informal discussion with other participants in small groups.
+
+<div class="notice--info">
+  {{ final-notice | markdownify }}
+</div>
 
 Any questions, read [more](faq/about/what-is-sorse) or [get in touch](contact/)!
 

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -10,12 +10,11 @@ header:
   overlay_image: /assets/images/sorse-banner.svg
   overlay_filter: 0.5
   actions:
-    - label: Join the mailing list
-      url: https://www.listserv.dfn.de/sympa/subscribe/sorsenews
+    - label: Access event material
+      url: programme/
     - label: Watch past events
       url: https://www.youtube.com/channel/UCJ1CwxvODyT-eb4K7HfelGA
 excerpt: International Series of Online Research Software Events
-fullcalendar: true
 ---
 
 <aside id="twitter-holder" class="sidebar__right sticky">
@@ -24,13 +23,13 @@ fullcalendar: true
 
 Welcome to SORSE - A **S**eries of **O**nline **R**esearch **S**oftware **E**vents - our international answer to the COVID-19-induced cancellation of many national RSE conferences. We want to provide an opportunity for RSEs to develop and grow their skills, build new collaborations and engage with RSEs worldwide.
 
-This is an open call to all RSEs and anyone involved with research software worldwide, to propose a talk, a workshop, a software demo, a panel or discussion, blog post or poster. After each event, SORSE will provide an opportunity for networking and informal discussion with other participants in small groups.
+This series has been an open call to all RSEs and anyone involved with research software worldwide, to propose a talk, a workshop, a software demo, a panel or discussion, blog post or poster. After each event, SORSE did provide an opportunity for networking and informal discussion with other participants in small groups.
 
-Any questions, read [more](faq/about/what-is-sorse), [get in touch](contact/), or see [upcoming events](#upcoming-events)!
+Any questions, read [more](faq/about/what-is-sorse) or [get in touch](contact/)!
 
-## Upcoming Events
+## Past Events
 
-{% include upcoming-events.html all=true %}
+Access abstracts, slides and videos through the [Programme]({{ "/programme/" | relative_url }}) page.
 
 
 ## Blog

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -22,13 +22,13 @@ excerpt: International Series of Online Research Software Events
 </aside>
 
 {% capture final-notice %}
-SORSE ended with it's [final event]({{ "/programme/finale/" | relative_url }})
-on March 24th. 2021. Thanks to all the contributors that submitted abstracts and
+SORSE ended with its [final event]({{ "/programme/finale/" | relative_url }})
+on March 24th 2021. Thanks to all the contributors who submitted abstracts and
 gave presentations, discussions, demonstrations, and thanks to everyone who
 participated in one of our sessions to make all of this possible.
 
 But this won't be the end of everything. There is still need for exchange
-within our emerging community of international research software engineers.
+within our international community of research software engineers.
 
 Stay tuned and keep an eye on the communication channels of
 [your national RSE chapter]({{ "/contact/chapters/" | relative_url }}).

--- a/_pages/programme/index.md
+++ b/_pages/programme/index.md
@@ -5,10 +5,5 @@ collection: events
 permalink: /programme/
 sidebar:
   nav:  programme
-fullcalendar: true
 classes: wide
 ---
-
-## Upcoming events
-
-{% include upcoming-events.html events=true posts=true onclick='tag' %}

--- a/_posts/programme/2020-06-23-call-for-contributions.md
+++ b/_posts/programme/2020-06-23-call-for-contributions.md
@@ -13,27 +13,5 @@ id: 1
 fullcalendar: true
 ---
 
-Were you going to submit something to an RSE conference this year? Do you have a project you’d like to share? Is there a talk/workshop/panel you’d like to see happen? Then you’ve found the right place!
-
-The call for abstracts has been closed. The final round of events can be seen at [the _Programme_ page]({{ "/programme" | relative_url }}).
+The call for abstracts has been closed and SORSE has ended. [Read more]({{ "/" | relative_url }}).
 {: .notice--info}
-
-You can make a contribution to one of the event types (see the left hand menu), and/or suggest an event in the [Wishlist]({% include fix-link.html link="/programme/wishlist" %}) that you’d like to see in the series. Take a look at the [Topic Bazaar]({% include fix-link.html link=site.data.committee.programme_teams.bazaar.internal %}) if you have an idea but want to find collaborators before submitting. We’re looking for both technical and soft skills and there are no set themes this year but if a theme emerges, we may group those events together to create a half day event or a run of events over a few weeks.
-
-We encourage contributions from all time zones and will schedule events on a day and at a time that suits the presenter. We would like to record events where appropriate. The Call for Contribution form asks for your permission to record the event, for you to give permission to provide your uploaded materials under a CC BY licence and be happy to publish them to [Zenodo](https://zenodo.org).
-
-We ask for these permissions so that 1) commmunity members in different timezones can watch your event, 2) make your contribution citable and 3) we can build an RSE resource on many different topics.
-
-The Call for Contributions form will remain **open continuously** and there will be a **rolling deadline at the end of the last day (UTC) of each month** (see [below](#next-submission-deadlines)), following which all contributions received over the previous month will be sent for review by the [Programme Committee]({% include fix-link.html link=site.data.committee.committees.programme.internal %}).
-
-The call is open to anyone wanting to propose a research software-related talk or event from anywhere in the world, regardless of your role.
-
-Please note that in the case of submissions from representatives of companies that relate to commercial products, the SORSE programme committee reserves the right to reject or request appropriate revisions at their discretion. To discuss the suitability of such a submission please contact SORSE.enquiries@gmail.com.
-
-Please have a look into our [schedule of events]({{ "/#upcoming-events" | relative_url }}) for details of what’s coming up.
-
-## Next submission deadlines
-
-{% include upcoming-events.html cfc_deadlines=true %}
-
-<a href="{{site.indico_base_event}}/abstracts" class="btn btn--success" target="_blank"><i class="fas fa-pen"></i> Submit an abstract</a>

--- a/_posts/programme/2020-06-23-call-for-contributions.md
+++ b/_posts/programme/2020-06-23-call-for-contributions.md
@@ -13,5 +13,5 @@ id: 1
 fullcalendar: true
 ---
 
-The call for abstracts has been closed and SORSE has ended. [Read more]({{ "/" | relative_url }}).
+The SORSE call for abstract submissions has now closed and the 2020/2021 series of events has ended. Take a look at the [programme]({{ "/programme/" | relative_url }}) page for details and videos of the past events.
 {: .notice--info}

--- a/_posts/programme/2020-06-24-ask-us-anything-sessions.md
+++ b/_posts/programme/2020-06-24-ask-us-anything-sessions.md
@@ -16,7 +16,3 @@ fullcalendar: true
 You can sign up to a 'Ask us Anything' session held on zoom where you can put suggestions to us for an event, run through how your idea would work with the tools that we are planning to use or anything else! Sign up [here](https://docs.google.com/forms/d/e/1FAIpQLScGEP7WEdS9-iJ2COKlpobSKH-RJHNMO7bc-smw2KcyoSNO-w/viewform) for one of the sessions.
 
 Alternatively, contact us through the UK RSE Slack workspace [#sorse_ask_us_anything](https://ukrse.slack.com/archives/C015ZEJHUH1).
-
-## Next sessions
-
-{% include upcoming-events.html ask_us_anything=true %}


### PR DESCRIPTION
concerning #442, this PR removes the links to upcoming events and adds a notice that SORSE has been ended. @jcohen02, would you please give it a quick read-through before I merge it?

https://1988-267395254-gh.circle-artifacts.com/0/SORSE/index.html

I also removed all upcoming events frames and cleaned the [call for contributions](https://1991-267395254-gh.circle-artifacts.com/0/SORSE/programme/call-for-contributions/index.html) 

We should still keep the summary page thing in mind, that's why I do not close #442 with this PR.